### PR TITLE
Runtime services supported

### DIFF
--- a/README
+++ b/README
@@ -24,7 +24,15 @@ Ubuntu Distro ARM64
 	autoconf automake libglib2.0-dev libtool libpcre3-dev
 	flex bison dkms libfdt-dev libbsd-dev
 
-2) To build and install (only if building from source)
+2) Kernel configuration
+
+Some tests depend on special Linux kernel configuration settings. These include:
+
+* CONFIG_CGROUP_FREEZER=y
+* CONFIG_DMI_SYSFS=y
+* CONFIG_EFI_TEST=m
+
+3) To build and install (only if building from source)
 
 	autoreconf -ivf
 	./configure

--- a/auto-packager/mkpackage.sh
+++ b/auto-packager/mkpackage.sh
@@ -23,7 +23,7 @@
 # Get fwts sources, strip out .git directory, add in necessary debian packaging
 # files, build source package ready for upload.
 #
-RELEASES="xenial bionic focal groovy"
+RELEASES="xenial bionic focal groovy hirsute"
 REPO=git://kernel.ubuntu.com/hwe/fwts.git
 RELEASE_TAR_URL=http://fwts.ubuntu.com/release
 FWTS=fwts

--- a/data/klog.json
+++ b/data/klog.json
@@ -5961,7 +5961,7 @@
    "compare_mode": "regex",
    "log_level": "LOG_LEVEL_HIGH",
    "pattern": "ACPI Error.*Namespace lookup failure, AE_NOT_FOUND",
-   "advice": "The kernel has detected an error trying to execute an Method and it cannot find an object. This is indicates a bug in the DSDT or SSDT AML code.",
+   "advice": "The kernel has detected an error trying to execute a method and it cannot find an object. This indicates a bug in the DSDT or SSDT AML code.",
    "label": "KlogAcpiNamespaceLookupFailure"
   },
   {

--- a/data/klog.json
+++ b/data/klog.json
@@ -5973,7 +5973,7 @@
   },
   {
    "compare_mode": "regex",
-   "log_level": "LOG_LEVEL_HIGH",
+   "log_level": "LOG_LEVEL_CRITICAL",
    "pattern": "ACPI Error.+psparse",
    "advice": "The ACPI engine has failed to execute some AML. The error message above lists the method that caused this error.",
    "label": "KlogAcpiParseOrExecFailure"

--- a/data/klog.json
+++ b/data/klog.json
@@ -5966,6 +5966,13 @@
   },
   {
    "compare_mode": "regex",
+   "log_level": "LOG_LEVEL_CRITICAL",
+   "pattern": "Could not resolve symbol.*, AE_NOT_FOUND",
+   "advice": "While evaluating one object, ACPI could not find another object that was being referenced. This indicates a bug in the DSDT or the SSDTs.",
+   "label": "KlogAcpiNamespaceLookupFailure"
+  },
+  {
+   "compare_mode": "regex",
    "log_level": "LOG_LEVEL_HIGH",
    "pattern": "ACPI Error.+psparse",
    "advice": "The ACPI engine has failed to execute some AML. The error message above lists the method that caused this error.",

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,27 @@
+fwts (20.12.00-0ubuntu1) hirsute; urgency=medium
+
+  [Alex Hung]
+  * acpi: method: define marcos for D3hot and D3cold
+  * acpi: fadt: X_GPE0/1_BLK can be zero when not used
+  * pci: maxreadreq: skip Intel video devices
+  * acpi: method: replace revision checks by fwts_method_test_revision
+  * dmicheck: add dmi version check to SMBIOS3
+  * lib: fwts_acpi_object_eval: add fwts_method_test_revision function
+  * lib: fix a function name typo in comment
+  * dmi: dmicheck: update type 4, 9 and 17 according to spec 3.4
+
+  [Colin Ian King]
+  * lib: replace FWTS_ACPI_FADT_PREFERRED_PM_PROFILE with function
+  * Replace FWTS_ARRAY_LEN with FWTS_ARRAY_SIZE
+  * sbbr/fadt: Clean up indentation of a few lines
+  * lib: fwts_firmware: cast 1 to UL to ensure no signed extension, clean up
+    comments
+  * src: Clean-up: remove trailing spaces and tabs from lines
+  * lib: fwts_efi_module: fix flags on device open
+  * acpi: fan: skip over fan info when the type field is NULL (LP: #1906540)
+
+ -- Ivan Hu <ivan.hu@ubuntu.com>  Thu, 17 Dec 2020 10:14:02 +0800
+
 fwts (20.11.00-0ubuntu1) hirsute; urgency=medium
 
   [Alex Hung]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,44 @@
+fwts (20.11.00-0ubuntu1) hirsute; urgency=medium
+
+  [Alex Hung]
+  * acpi/wmi: update WMI known GUIDs from Linux kernel
+  * acpi/pptt: add a warning for type 2 depreciation
+  * fwts-test: sync up with pptt type 2 changes
+  * auto-packager:mkpackage.sh: add hirsute
+  * klog.json: add ACPI error "Could not resolve symbol ..."
+  * klog.json: fix grammar mistakes
+  * klog.json: sync AE_NOT_FOUND severity with a5d747194a9e
+  * fwts-test: sync up with klog (e09cbe166d4c)
+  * mtrr: refine memory type above 4GB on AMD platforms
+  * mtrr: add tests for enable bits in MTRR_DEF_TYPE MSR
+  * lib: refactor fwts_acpi_is_reduced_hardware
+  * acpi/ec: check _GPE is not used for hardware-reduced
+  * cpu/msr: skip MSR MCG_CTL (0x17b) for AMD CPUS
+  * acpi/method: fix _SxW which can return 4
+
+  [Colin Ian King]
+  * ACPICA: Update to version 20201008
+  * fwts-test: sync up output with the latest ACPICA 20201008 release
+  * lib: fwts_json: fix output so that it is machine parsable (LP: #1902249)
+  * lib: fwts_cmos: remove cli/sti assembler from cmos reading
+  * ACPICA: Update to version 20201113
+  * fwts-test: sync up output with the latest ACPICA 20201113
+  * lib: fwts_json: fix memory leaks on error return paths
+  * lib: fwts_json: fix output so that it is machine parsable (LP: #1902249)
+
+  [Heinrich Schuchardt]
+  * README: document required kernel configuration
+  * lib: avoid bus error in fwts_safe_memcpy
+  * lib: enable /dev/mem access on aarch64
+
+  [Ivan Hu]
+  * lib: fwts_tpm: move some tpm funcitons to lib
+  * tpmevlog: add tests for snatic check of the Tpm event log
+  * tpmevlog: add tests for snatic check of the TPM event sha1 format log
+  * lib: fwts_acpi_table.c: fix build fail
+
+ -- Ivan Hu <ivan.hu@ubuntu.com>  Wed, 25 Nov 2020 17:20:45 +0800
+
 fwts (20.09.00-0ubuntu1) groovy; urgency=medium
 
   [Alex Hung]

--- a/fwts-test/klog-0001/klog-0001.log
+++ b/fwts-test/klog-0001/klog-0001.log
@@ -3105,8 +3105,8 @@ klog            Kernel message: [ 0.104297] ACPI Error (psargs-0359):
 klog            [OSYS] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.104304] ACPI Error (psparse-0537): Method
@@ -3215,8 +3215,8 @@ klog            Kernel message: [ 0.118277] ACPI Error (psargs-0359):
 klog            [SUPP] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.118284] ACPI Error (psparse-0537): Method
@@ -3403,8 +3403,8 @@ klog            Namespace lookup failure, AE_NOT_FOUND (20110112
 klog            /psargs-359)
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [MEDIUM] KlogBiosMtrrsInconsistentAcrossCPUs: Test
 klog            1, MEDIUM Kernel message: [ 0.160449] mtrr: your CPUs had
@@ -3447,8 +3447,8 @@ klog            Kernel message: [ 0.165683] ACPI Error: [CDW1] Namespace
 klog            lookup failure, AE_NOT_FOUND (20110112/psargs-359)
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.165689] ACPI Error: Method parse/execution
@@ -3532,8 +3532,8 @@ klog            Kernel message: [ 0.169111] ACPI Error: [HPTF] Namespace
 klog            lookup failure, AE_NOT_FOUND (20110112/psargs-359)
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.169117] ACPI Error: Method parse/execution
@@ -3783,8 +3783,8 @@ klog            Kernel message: [ 0.176410] ACPI Error: [RAMB] Namespace
 klog            lookup failure, AE_NOT_FOUND (20110413/psargs-359)
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [MEDIUM] KlogAcpiIncorrectTableChecksum: Test 1,
 klog            MEDIUM Kernel message: [ 0.176680] ACPI Warning: Incorrect
@@ -4024,16 +4024,16 @@ klog            Kernel message: [ 0.182199] ACPI Error: [Z012] Namespace
 klog            lookup failure, AE_NOT_FOUND (20110112/psargs-359)
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiNamespaceLookupFailure: Test 1, HIGH
 klog            Kernel message: [ 0.182639] ACPI Error (psargs-0359):
 klog            [ECEN] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.182645] ACPI Error (psparse-0537): Method
@@ -4183,8 +4183,8 @@ klog            Kernel message: [ 0.185673] ACPI Error (dswload-0659):
 klog            [___P] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiInvalidTableLength: Test 1, HIGH
 klog            Kernel message: [ 0.185686] ACPI Error (psparse-0537):
@@ -4295,8 +4295,8 @@ klog            Kernel message: [ 0.188487] ACPI Error (psargs-0359): q z
 klog            Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [MEDIUM] KlogAcpiIncorrectTableChecksum: Test 1,
 klog            MEDIUM Kernel message: [ 0.188669] ACPI Warning: Incorrect
@@ -4345,8 +4345,8 @@ klog            Kernel message: [ 0.189515] ACPI Error (psargs-0359):
 klog            [CVCL] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.189522] ACPI Error (psparse-0537): Method
@@ -4558,8 +4558,8 @@ klog            Kernel message: [ 0.199465] ACPI Error: [CDW1] Namespace
 klog            lookup failure, AE_NOT_FOUND (20110413/psargs-359)
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.199471] ACPI Error: Method parse/execution
@@ -5148,8 +5148,8 @@ klog            Kernel message: [ 0.228032] ACPI Error (psargs-0359):
 klog            [_PR_.C002._PPC] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.228041] ACPI Error (psparse-0537): Method
@@ -5199,8 +5199,8 @@ klog            Kernel message: [ 0.229639] ACPI Error (psargs-0359):
 klog            [CDW1] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.229644] ACPI Error (psparse-0537): Method
@@ -5787,8 +5787,8 @@ klog            Kernel message: [ 0.285468] ACPI Error (psargs-0359):
 klog            [_PR_.CPU0._PPC] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.285476] ACPI Error (psparse-0537): Method
@@ -5866,8 +5866,8 @@ klog            Kernel message: [ 0.302946] ACPI Error (psargs-0359):
 klog            [HPTF] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.302952] ACPI Error (psparse-0537): Method
@@ -6482,8 +6482,8 @@ klog            Kernel message: [ 0.332160] ACPI Error (dswload-0677):
 klog            [PCI0] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.332167] ACPI Error (psparse-0537): Method
@@ -6586,8 +6586,8 @@ klog            Kernel message: [ 0.333765] ACPI Error (psargs-0359):
 klog            [FZHD] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.333771] ACPI Error (psparse-0537): Method
@@ -6677,8 +6677,8 @@ klog            Kernel message: [ 0.337662] ACPI Error (psargs-0359):
 klog            [URES] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.337662] ACPI Error (psparse-0537): Method
@@ -7467,8 +7467,8 @@ klog            Kernel message: [ 0.375585] ACPI Error (dswload-0677):
 klog            [USB0] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.375609] ACPI Error (psparse-0537): Method
@@ -7666,8 +7666,8 @@ klog            Namespace lookup failure, AE_NOT_FOUND (20110112
 klog            /psargs-359)
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.390354] ACPI Error: Method parse/execution
@@ -7967,8 +7967,8 @@ klog            Kernel message: [ 0.426823] ACPI Error (psargs-0359):
 klog            [_PR_.CPU0._PSS] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.426833] ACPI Error (psparse-0537): Method
@@ -8072,8 +8072,8 @@ klog            Kernel message: [ 0.451517] ACPI Error (psargs-0359):
 klog            [GUR_._BAS] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.451682] ACPI Error (psparse-0537): Method
@@ -8536,8 +8536,8 @@ klog            Namespace lookup failure, AE_NOT_FOUND (20110112
 klog            /psargs-359)
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.540046] ACPI Error: Method parse/execution
@@ -8776,8 +8776,8 @@ klog            Kernel message: [ 0.600451] ACPI Error (psargs-0359):
 klog            [_SB_.PCI0.EGBA] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.600456] ACPI Error (psparse-0537): Method
@@ -8894,8 +8894,8 @@ klog            [_SB_.PCI0.EC__.HOTT] Namespace lookup failure,
 klog            AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.627255] ACPI Error (psparse-0537): Method
@@ -9037,8 +9037,8 @@ klog            Kernel message: [ 0.655369] ACPI Error (psargs-0359):
 klog            [_SB_.PCI0.PSKB] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.655376] ACPI Error (psparse-0537): Method
@@ -9054,8 +9054,8 @@ klog            Kernel message: [ 0.655576] ACPI Error (psargs-0359):
 klog            [_SB_.PCI0.PSMS] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.655581] ACPI Error (psparse-0537): Method
@@ -9429,8 +9429,8 @@ klog            Kernel message: [ 0.721822] ACPI Error (dswload-0659):
 klog            [USB0] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.722199] ACPI Error (psparse-0537): Method
@@ -9639,8 +9639,8 @@ klog            Kernel message: [ 0.782613] ACPI Error (psargs-0359):
 klog            [RAMB] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [MEDIUM] KlogAcpiIncorrectTableChecksum: Test 1,
 klog            MEDIUM Kernel message: [ 0.783246] ACPI Warning: Incorrect
@@ -9767,24 +9767,24 @@ klog            Kernel message: [ 0.810687] ACPI Error (dswload-0659):
 klog            [DD02] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiNamespaceLookupFailure: Test 1, HIGH
 klog            Kernel message: [ 0.810756] ACPI Error (dswload-0659):
 klog            [EHC1] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiNamespaceLookupFailure: Test 1, HIGH
 klog            Kernel message: [ 0.820565] ACPI Error: [FZHD] Namespace
 klog            lookup failure, AE_NOT_FOUND (20110112/psargs-359)
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.820571] ACPI Error: Method parse/execution
@@ -9935,8 +9935,8 @@ klog            Kernel message: [ 0.879606] ACPI Error (psargs-0359):
 klog            [MPEN] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 0.879794] ACPI Error (psparse-0537): Method
@@ -10401,8 +10401,8 @@ klog            Kernel message: [ 1.167050] ACPI Error: [CDW1] Namespace
 klog            lookup failure, AE_NOT_FOUND (20110316/psargs-359)
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 1.167226] ACPI Error: Method parse/execution
@@ -10486,8 +10486,8 @@ klog            Kernel message: [ 1.186079] ACPI Error: [BRTW] Namespace
 klog            lookup failure, AE_NOT_FOUND (20110112/psargs-359)
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 1.186087] ACPI Error: Method parse/execution
@@ -10797,8 +10797,8 @@ klog            Kernel message: [ 1.314561] ACPI Error: [ECPU] Namespace
 klog            lookup failure, AE_NOT_FOUND (20110112/psargs-359)
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 1.314567] ACPI Error: Method parse/execution
@@ -10873,8 +10873,8 @@ klog            Kernel message: [ 1.381481] ACPI Error (dswload-0659):
 klog            [PCI0] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiResolveOpBadType: Test 1, HIGH
 klog            Kernel message: [ 1.384655] ACPI Error: Needed [Buffer
@@ -10971,8 +10971,8 @@ klog            Kernel message: [ 1.488986] ACPI Error (psargs-0359):
 klog            [GTF0] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 1.488991] ACPI Error (psparse-0537): Method
@@ -11177,8 +11177,8 @@ klog            Kernel message: [ 1.605465] ACPI Error: [RAMB] Namespace
 klog            lookup failure, AE_NOT_FOUND (20110112/psargs-359)
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 1.616034] ACPI Error (psparse-0537): Method
@@ -11230,8 +11230,8 @@ klog            Kernel message: [ 1.648580] ACPI Error: [SMS_] Namespace
 klog            lookup failure, AE_NOT_FOUND (20110112/psargs-359)
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 1.648589] ACPI Error: Method parse/execution
@@ -11476,8 +11476,8 @@ klog            Kernel message: [ 1.900224] ACPI Error: [NPSS] Namespace
 klog            lookup failure, AE_NOT_FOUND (20110112/psargs-359)
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 1.900238] ACPI Error: Method parse/execution
@@ -11538,8 +11538,8 @@ klog            Kernel message: [ 1.907422] ACPI Error: [GTF0] Namespace
 klog            lookup failure, AE_NOT_FOUND (20110112/psargs-359)
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 1.907427] ACPI Error: Method parse/execution
@@ -11856,8 +11856,8 @@ klog            Kernel message: [ 2.081502] ACPI Error (psargs-0359):
 klog            [NPSS] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 2.081508] ACPI Error (psparse-0537): Method
@@ -12052,8 +12052,8 @@ klog            Kernel message: [ 2.227407] ACPI Error (psargs-0359):
 klog            [GTF1] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 2.227411] ACPI Error (psparse-0537): Method
@@ -12159,8 +12159,8 @@ klog            Kernel message: [ 2.283579] ACPI Error (psargs-0359):
 klog            [_T_0] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 2.283585] ACPI Error (psparse-0537): Method
@@ -12307,8 +12307,8 @@ klog            Kernel message: [ 2.440684] ACPI Error (psargs-0359):
 klog            [SMS_] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 2.440692] ACPI Error (psparse-0537): Method
@@ -12412,8 +12412,8 @@ klog            Kernel message: [ 2.634350] ACPI Error: [GTF1] Namespace
 klog            lookup failure, AE_NOT_FOUND (20110112/psargs-359)
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 2.634355] ACPI Error: Method parse/execution
@@ -12553,8 +12553,8 @@ klog            [_SB_.PCI0.GFX0.DD02._BCL] Namespace lookup failure,
 klog            AE_NOT_FOUND (20110112/psargs-359)
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 2.861812] ACPI Error: Method parse/execution
@@ -13569,8 +13569,8 @@ klog            Kernel message: [ 10.289821] ACPI Error (psargs-0359):
 klog            [_PR_.CPU0._CST] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 10.289828] ACPI Error (psparse-0537): Method
@@ -14250,8 +14250,8 @@ klog            Kernel message: [ 13.452167] ACPI Error (psargs-0359):
 klog            [_PR_.C001] Namespace lookup failure, AE_NOT_FOUND
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 13.452177] ACPI Error (psparse-0537): Method
@@ -15116,8 +15116,8 @@ klog            Namespace lookup failure, AE_NOT_FOUND (20110112
 klog            /psargs-359)
 klog            
 klog            ADVICE: The kernel has detected an error trying to execute
-klog            an Method and it cannot find an object. This is indicates
-klog            a bug in the DSDT or SSDT AML code.
+klog            a method and it cannot find an object. This indicates a
+klog            bug in the DSDT or SSDT AML code.
 klog            
 klog            FAILED [HIGH] KlogAcpiObjectNotFound: Test 1, HIGH Kernel
 klog            message: [ 42.490202] ACPI Error: Method parse/execution

--- a/fwts-test/syntaxcheck-0001/syntaxcheck-0001.log
+++ b/fwts-test/syntaxcheck-0001/syntaxcheck-0001.log
@@ -951,6 +951,20 @@ syntaxcheck     thread enters the method and blocks and then a second
 syntaxcheck     thread also executes the method, ending up in two attempts
 syntaxcheck     to create the object and causing a failure.
 syntaxcheck     
+syntaxcheck     FAILED [LOW] AMLAsmUnknown: Test 1, Assembler remark in
+syntaxcheck     line 67
+syntaxcheck     Line | AML source
+syntaxcheck     ----------------------------------------------------------
+syntaxcheck     00064|                  0x00, 0x00, 0x00, 0x00                           // ....
+syntaxcheck     00065|             })
+syntaxcheck     00066|             Concatenate (STS0, TEMP, Local2)
+syntaxcheck     00067|             _OSC (ToUUID ("4077a616-290c-47be-9ebd-d87058713953") /* Unknown UUID */, REVS, SIZE, Local2)
+syntaxcheck          |                                                               ^
+syntaxcheck          | Remark 2184: Unknown UUID string  
+syntaxcheck     00068|         }
+syntaxcheck     00069| 
+syntaxcheck     00070|         Method (_OSC, 4, NotSerialized)  // _OSC: Operating System Capabilities
+syntaxcheck     ==========================================================
 syntaxcheck     FAILED [LOW] AMLAsmASL_MSG_SERIALIZED_REQUIRED: Test 1,
 syntaxcheck     Assembler remark in line 70
 syntaxcheck     Line | AML source
@@ -973,6 +987,20 @@ syntaxcheck     thread enters the method and blocks and then a second
 syntaxcheck     thread also executes the method, ending up in two attempts
 syntaxcheck     to create the object and causing a failure.
 syntaxcheck     
+syntaxcheck     FAILED [LOW] AMLAsmUnknown: Test 1, Assembler remark in
+syntaxcheck     line 78
+syntaxcheck     Line | AML source
+syntaxcheck     ----------------------------------------------------------
+syntaxcheck     00075|             CreateDWordField (Arg0, 0x04, IID1)
+syntaxcheck     00076|             CreateDWordField (Arg0, 0x08, IID2)
+syntaxcheck     00077|             CreateDWordField (Arg0, 0x0C, IID3)
+syntaxcheck     00078|             Name (UID0, ToUUID ("4077a616-290c-47be-9ebd-d87058713953") /* Unknown UUID */)
+syntaxcheck          |                                                                     ^
+syntaxcheck          | Remark 2184: Unknown UUID string  
+syntaxcheck     00079|             CreateDWordField (UID0, 0x00, EID0)
+syntaxcheck     00080|             CreateDWordField (UID0, 0x04, EID1)
+syntaxcheck     00081|             CreateDWordField (UID0, 0x08, EID2)
+syntaxcheck     ==========================================================
 syntaxcheck     FAILED [LOW] AMLAsmUnknown: Test 1, Assembler remark in
 syntaxcheck     line 78
 syntaxcheck     Line | AML source
@@ -1037,6 +1065,20 @@ syntaxcheck     thread enters the method and blocks and then a second
 syntaxcheck     thread also executes the method, ending up in two attempts
 syntaxcheck     to create the object and causing a failure.
 syntaxcheck     
+syntaxcheck     FAILED [LOW] AMLAsmUnknown: Test 1, Assembler remark in
+syntaxcheck     line 140
+syntaxcheck     Line | AML source
+syntaxcheck     ----------------------------------------------------------
+syntaxcheck     00137|                  0x00, 0x00, 0x00, 0x00                           // ....
+syntaxcheck     00138|             })
+syntaxcheck     00139|             Concatenate (STS1, TEMP, Local2)
+syntaxcheck     00140|             _OSC (ToUUID ("4077a616-290c-47be-9ebd-d87058713953") /* Unknown UUID */, REVS, SIZE, Local2)
+syntaxcheck          |                                                               ^
+syntaxcheck          | Remark 2184: Unknown UUID string  
+syntaxcheck     00141|         }
+syntaxcheck     00142| 
+syntaxcheck     00143|         Method (_OSC, 4, NotSerialized)  // _OSC: Operating System Capabilities
+syntaxcheck     ==========================================================
 syntaxcheck     FAILED [LOW] AMLAsmASL_MSG_SERIALIZED_REQUIRED: Test 1,
 syntaxcheck     Assembler remark in line 143
 syntaxcheck     Line | AML source
@@ -1059,6 +1101,20 @@ syntaxcheck     thread enters the method and blocks and then a second
 syntaxcheck     thread also executes the method, ending up in two attempts
 syntaxcheck     to create the object and causing a failure.
 syntaxcheck     
+syntaxcheck     FAILED [LOW] AMLAsmUnknown: Test 1, Assembler remark in
+syntaxcheck     line 151
+syntaxcheck     Line | AML source
+syntaxcheck     ----------------------------------------------------------
+syntaxcheck     00148|             CreateDWordField (Arg0, 0x04, IID1)
+syntaxcheck     00149|             CreateDWordField (Arg0, 0x08, IID2)
+syntaxcheck     00150|             CreateDWordField (Arg0, 0x0C, IID3)
+syntaxcheck     00151|             Name (UID1, ToUUID ("4077a616-290c-47be-9ebd-d87058713953") /* Unknown UUID */)
+syntaxcheck          |                                                                     ^
+syntaxcheck          | Remark 2184: Unknown UUID string  
+syntaxcheck     00152|             CreateDWordField (UID1, 0x00, EID0)
+syntaxcheck     00153|             CreateDWordField (UID1, 0x04, EID1)
+syntaxcheck     00154|             CreateDWordField (UID1, 0x08, EID2)
+syntaxcheck     ==========================================================
 syntaxcheck     FAILED [LOW] AMLAsmUnknown: Test 1, Assembler remark in
 syntaxcheck     line 151
 syntaxcheck     Line | AML source
@@ -1101,11 +1157,11 @@ syntaxcheck     00189|                     Load (CST1, HC1) /* \_PR_.CPU1.HC1_ *
 syntaxcheck     00190|                 }
 syntaxcheck     00191|             }
 syntaxcheck     ==========================================================
-syntaxcheck     Table SSDT (5) reassembly: Found 0 errors, 0 warnings, 10
+syntaxcheck     Table SSDT (5) reassembly: Found 0 errors, 0 warnings, 14
 syntaxcheck     remarks.
 syntaxcheck     
 syntaxcheck     
 syntaxcheck     ==========================================================
-syntaxcheck     2 passed, 67 failed, 0 warning, 0 aborted, 0 skipped, 0
+syntaxcheck     2 passed, 71 failed, 0 warning, 0 aborted, 0 skipped, 0
 syntaxcheck     info only.
 syntaxcheck     ==========================================================

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: fwts
-version: V20.11.00
+version: V20.12.00
 summary: The Firmware Test Suite (FWTS)
 description: This is a firmware test suite that performs sanity checks on system firmware. It is intended to identify BIOS and ACPI errors and if appropriate it will try to explain the errors and give advice to help workaround or fix firmware bugs.  It is primarily intended to be a Linux-centric firmware troubleshooting tool.
 confinement: strict

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: fwts
-version: V20.09.00
+version: V20.11.00
 summary: The Firmware Test Suite (FWTS)
 description: This is a firmware test suite that performs sanity checks on system firmware. It is intended to identify BIOS and ACPI errors and if appropriate it will try to explain the errors and give advice to help workaround or fix firmware bugs.  It is primarily intended to be a Linux-centric firmware troubleshooting tool.
 confinement: strict

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -184,6 +184,7 @@ fwts_SOURCES = main.c 				\
 	pci/aspm/aspm.c 			\
 	pci/crs/crs.c 				\
 	pci/maxreadreq/maxreadreq.c 		\
+	tpm/tpmevlog/tpmevlog.c			\
 	tpm/tpmevlogdump/tpmevlogdump.c		\
 	uefi/csm/csm.c 				\
 	uefi/uefidump/uefidump.c 		\

--- a/src/acpi/aspt/aspt.c
+++ b/src/acpi/aspt/aspt.c
@@ -27,21 +27,7 @@
 #include <string.h>
 
 static fwts_acpi_table_info *table;
-
-static int aspt_init(fwts_framework *fw)
-{
-
-	if (fwts_acpi_find_table(fw, "ASPT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI ASPT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(ASPT, &table)
 
 /*
  *  ASPT Table
@@ -101,7 +87,7 @@ static fwts_framework_minor_test aspt_tests[] = {
 
 static fwts_framework_ops aspt_ops = {
 	.description = "ASPT Table test.",
-	.init        = aspt_init,
+	.init        = ASPT_init,
 	.minor_tests = aspt_tests
 };
 

--- a/src/acpi/bert/bert.c
+++ b/src/acpi/bert/bert.c
@@ -27,20 +27,7 @@
 #include <string.h>
 
 static fwts_acpi_table_info *table;
-
-static int bert_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "BERT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI BERT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(BERT, &table)
 
 /*
  *  For BERT refer to 18.3.1 Boot Error Record Table
@@ -192,7 +179,7 @@ static fwts_framework_minor_test bert_tests[] = {
 
 static fwts_framework_ops bert_ops = {
 	.description = "BERT Boot Error Record Table test.",
-	.init        = bert_init,
+	.init        = BERT_init,
 	.minor_tests = bert_tests
 };
 

--- a/src/acpi/bgrt/bgrt.c
+++ b/src/acpi/bgrt/bgrt.c
@@ -28,19 +28,7 @@
 #include <ctype.h>
 
 static fwts_acpi_table_info *table;
-
-static int bgrt_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "BGRT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI BGRT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-	return FWTS_OK;
-}
+acpi_table_init(BGRT, &table)
 
 /*
  *  BGRT Boot Graphics Resource Table
@@ -91,7 +79,7 @@ static fwts_framework_minor_test bgrt_tests[] = {
 
 static fwts_framework_ops bgrt_ops = {
 	.description = "BGRT Boot Graphics Resource Table test.",
-	.init        = bgrt_init,
+	.init        = BGRT_init,
 	.minor_tests = bgrt_tests
 };
 

--- a/src/acpi/boot/boot.c
+++ b/src/acpi/boot/boot.c
@@ -18,7 +18,7 @@
  */
 #include "fwts.h"
 
-#if defined(FWTS_HAS_ACPI)
+#if defined(FWTS_HAS_ACPI) && !(FWTS_ARCH_AARCH64)
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/acpi/cpep/cpep.c
+++ b/src/acpi/cpep/cpep.c
@@ -28,19 +28,7 @@
 #include <ctype.h>
 
 static fwts_acpi_table_info *table;
-
-static int cpep_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "CPEP", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI CPEP table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-	return FWTS_OK;
-}
+acpi_table_init(CPEP, &table)
 
 /*
  *  CPEP Corrected Platform Error Polling Table
@@ -121,7 +109,7 @@ static fwts_framework_minor_test cpep_tests[] = {
 
 static fwts_framework_ops cpep_ops = {
 	.description = "CPEP Corrected Platform Error Polling Table test.",
-	.init        = cpep_init,
+	.init        = CPEP_init,
 	.minor_tests = cpep_tests
 };
 

--- a/src/acpi/csrt/csrt.c
+++ b/src/acpi/csrt/csrt.c
@@ -27,19 +27,7 @@
 #include <string.h>
 
 static fwts_acpi_table_info *table;
-
-static int csrt_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "CSRT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI CSRT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-	return FWTS_OK;
-}
+acpi_table_init(CSRT, &table)
 
 /*
  *  CSRT Core System Resource Table
@@ -239,7 +227,7 @@ static fwts_framework_minor_test csrt_tests[] = {
 
 static fwts_framework_ops csrt_ops = {
 	.description = "CSRT Core System Resource Table test.",
-	.init        = csrt_init,
+	.init        = CSRT_init,
 	.minor_tests = csrt_tests
 };
 

--- a/src/acpi/dbgp/dbgp.c
+++ b/src/acpi/dbgp/dbgp.c
@@ -18,7 +18,7 @@
  */
 #include "fwts.h"
 
-#if defined(FWTS_HAS_ACPI)
+#if defined(FWTS_HAS_ACPI) && !(FWTS_ARCH_AARCH64)
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/acpi/dbgp/dbgp.c
+++ b/src/acpi/dbgp/dbgp.c
@@ -27,21 +27,7 @@
 #include <string.h>
 
 static fwts_acpi_table_info *table;
-
-static int dbgp_init(fwts_framework *fw)
-{
-
-	if (fwts_acpi_find_table(fw, "DBGP", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI DBGP table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(DBGP, &table)
 
 /*
  *  DBGP Table
@@ -127,7 +113,7 @@ static fwts_framework_minor_test dbgp_tests[] = {
 
 static fwts_framework_ops dbgp_ops = {
 	.description = "DBGP (Debug Port) Table test.",
-	.init        = dbgp_init,
+	.init        = DBGP_init,
 	.minor_tests = dbgp_tests
 };
 

--- a/src/acpi/devices/ec/ec.c
+++ b/src/acpi/devices/ec/ec.c
@@ -93,6 +93,14 @@ static void method_test_GPE_return(
 	FWTS_UNUSED(buf);
 	bool failed = false;
 
+	if (fwts_acpi_is_reduced_hardware(fw)) {
+		fwts_failed(fw, LOG_LEVEL_HIGH,
+			"MethodGPEExist",
+			"%s is not required for Hardware-reduced ACPI platforms",
+			name);
+		return;
+	}
+
 	switch (obj->Type) {
 	case ACPI_TYPE_INTEGER:
 		if (obj->Integer.Value <= 255)

--- a/src/acpi/dppt/dppt.c
+++ b/src/acpi/dppt/dppt.c
@@ -27,20 +27,7 @@
 #include <string.h>
 
 static fwts_acpi_table_info *table;
-
-static int dppt_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "DPPT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI DPPT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(DPPT, &table)
 
 static int dppt_test1(fwts_framework *fw)
 {
@@ -64,7 +51,7 @@ static fwts_framework_minor_test dppt_tests[] = {
 
 static fwts_framework_ops dppt_ops = {
 	.description = "DPPT DMA Protection Policy Table test",
-	.init        = dppt_init,
+	.init        = DPPT_init,
 	.minor_tests = dppt_tests
 };
 

--- a/src/acpi/drtm/drtm.c
+++ b/src/acpi/drtm/drtm.c
@@ -28,19 +28,7 @@
 #include <ctype.h>
 
 static fwts_acpi_table_info *table;
-
-static int drtm_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "DRTM", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI DRTM table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-	return FWTS_OK;
-}
+acpi_table_init(DRTM, &table)
 
 /*
  *  DRTM D-RTM Resources Table
@@ -153,7 +141,7 @@ static fwts_framework_minor_test drtm_tests[] = {
 
 static fwts_framework_ops drtm_ops = {
 	.description = "DRTM D-RTM Resources Table test.",
-	.init        = drtm_init,
+	.init        = DRTM_init,
 	.minor_tests = drtm_tests
 };
 

--- a/src/acpi/ecdt/ecdt.c
+++ b/src/acpi/ecdt/ecdt.c
@@ -29,21 +29,7 @@
 #include "fwts_acpi_object_eval.h"
 
 static fwts_acpi_table_info *table;
-
-static int ecdt_init(fwts_framework *fw)
-{
-
-	if (fwts_acpi_find_table(fw, "ECDT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI ECDT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(ECDT, &table)
 
 /*
  *  See ACPI 6.0, Section 5.2.15
@@ -213,7 +199,7 @@ static fwts_framework_minor_test ecdt_tests[] = {
 
 static fwts_framework_ops ecdt_ops = {
 	.description = "ECDT Embedded Controller Boot Resources Table test.",
-	.init        = ecdt_init,
+	.init        = ECDT_init,
 	.minor_tests = ecdt_tests
 };
 

--- a/src/acpi/einj/einj.c
+++ b/src/acpi/einj/einj.c
@@ -26,19 +26,7 @@
 #include <ctype.h>
 
 static fwts_acpi_table_info *table;
-
-static int einj_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "EINJ", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI EINJ table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-	return FWTS_OK;
-}
+acpi_table_init(EINJ, &table)
 
 /*
  *  EINJ Error Injection Table
@@ -143,7 +131,7 @@ static fwts_framework_minor_test einj_tests[] = {
 
 static fwts_framework_ops einj_ops = {
 	.description = "EINJ Error Injection Table test.",
-	.init        = einj_init,
+	.init        = EINJ_init,
 	.minor_tests = einj_tests
 };
 

--- a/src/acpi/erst/erst.c
+++ b/src/acpi/erst/erst.c
@@ -27,19 +27,7 @@
 #include <string.h>
 
 static fwts_acpi_table_info *table;
-
-static int erst_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "ERST", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI ERST table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-	return FWTS_OK;
-}
+acpi_table_init(ERST, &table)
 
 /*
  *  ERST Extended System Description Table
@@ -180,7 +168,7 @@ static fwts_framework_minor_test erst_tests[] = {
 
 static fwts_framework_ops erst_ops = {
 	.description = "ERST Error Record Serialization Table test.",
-	.init        = erst_init,
+	.init        = ERST_init,
 	.minor_tests = erst_tests
 };
 

--- a/src/acpi/facs/facs.c
+++ b/src/acpi/facs/facs.c
@@ -28,19 +28,7 @@
 #include <ctype.h>
 
 static fwts_acpi_table_info *table;
-
-static int facs_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "FACS", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI FACS table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-	return FWTS_OK;
-}
+acpi_table_init(FACS, &table)
 
 /*
  *  FACS Firmware ACPI Control Structure test
@@ -157,7 +145,7 @@ static fwts_framework_minor_test facs_tests[] = {
 
 static fwts_framework_ops facs_ops = {
 	.description = "FACS Firmware ACPI Control Structure test.",
-	.init        = facs_init,
+	.init        = FACS_init,
 	.minor_tests = facs_tests
 };
 

--- a/src/acpi/fadt/fadt.c
+++ b/src/acpi/fadt/fadt.c
@@ -80,7 +80,7 @@ static int fadt_init(fwts_framework *fw)
 	 * required (5.2.10) is we are not in reduced hardware
 	 * mode
 	 */
-	if (!fwts_acpi_is_reduced_hardware(fadt)) {
+	if (!fwts_acpi_is_reduced_hardware(fw)) {
 		if (fwts_acpi_find_table(fw, "FACS", 0, &table) != FWTS_OK) {
 			fwts_log_error(fw, "Cannot read ACPI table FACS.");
 			return FWTS_ERROR;
@@ -245,7 +245,7 @@ static void acpi_table_check_fadt_firmware_ctrl(fwts_framework *fw)
 
 	/* for more recent FADTs, things get more complicated */
 	if (fadt->firmware_control == 0 && fadt->x_firmware_ctrl == 0) {
-		if (fwts_acpi_is_reduced_hardware(fadt)) {
+		if (fwts_acpi_is_reduced_hardware(fw)) {
 			fwts_passed(fw,
 				    "FADT 32 bit FIRMWARE_CONTROL and "
 				    "64 bit X_FIRMWARE_CONTROL (FACS "
@@ -443,7 +443,7 @@ static void acpi_table_check_fadt_reduced_hardware(fwts_framework *fw)
 	static const fwts_acpi_gas null_gas;
 	uint32_t flag_mask;
 
-	rhw = fwts_acpi_is_reduced_hardware(fadt);
+	rhw = fwts_acpi_is_reduced_hardware(fw);
 	fwts_log_info(fw, "FADT indicates ACPI %s in reduced hardware mode.",
 		      rhw ? IS : IS_NOT);
 
@@ -1521,7 +1521,7 @@ static void acpi_table_check_fadt_p_lvl3_lat(fwts_framework *fw, uint64_t pblk)
 
 static void acpi_table_check_fadt_x_gpex_blk(fwts_framework *fw) {
 
-	if (fwts_acpi_is_reduced_hardware(fadt))
+	if (fwts_acpi_is_reduced_hardware(fw))
 		return;
 
 	if (fadt->x_gpe0_blk.access_width == 1)
@@ -1547,7 +1547,7 @@ static void acpi_table_check_fadt_x_gpex_blk(fwts_framework *fw) {
 
 static void acpi_table_check_fadt_sleep_control_reg(fwts_framework *fw)
 {
-	if (fwts_acpi_is_reduced_hardware(fadt)) {
+	if (fwts_acpi_is_reduced_hardware(fw)) {
 		if (fadt->sleep_control_reg.address == 0)
 			fwts_passed(fw, "FADT SLEEP_CONTROL_REG not in use.");
 		else {
@@ -1577,7 +1577,7 @@ static void acpi_table_check_fadt_sleep_control_reg(fwts_framework *fw)
 
 static void acpi_table_check_fadt_sleep_status_reg(fwts_framework *fw)
 {
-	if (fwts_acpi_is_reduced_hardware(fadt)) {
+	if (fwts_acpi_is_reduced_hardware(fw)) {
 		if (fadt->sleep_status_reg.address == 0)
 			fwts_passed(fw, "FADT SLEEP_STATUS_REG not in use.");
 		else {
@@ -1620,7 +1620,7 @@ static int fadt_test1(fwts_framework *fw)
 	 * there is no other info (as far as this author knows) that can be
 	 * used to verify that the value is correct.
 	 */
-	if (!fwts_acpi_is_reduced_hardware(fadt)) {
+	if (!fwts_acpi_is_reduced_hardware(fw)) {
 		fwts_log_info(fw, "FADT SCI_INT is %" PRIu8, fadt->sci_int);
 		acpi_table_check_fadt_smi_cmd(fw);
 		acpi_table_check_fadt_acpi_enable(fw);
@@ -1690,7 +1690,7 @@ static int fadt_test2(fwts_framework *fw)
 	uint32_t port, width, val32;
 	int ret = FWTS_OK;
 
-	if (fwts_acpi_is_reduced_hardware(fadt)) {
+	if (fwts_acpi_is_reduced_hardware(fw)) {
 		fwts_skipped(fw, "In reduced hardware mode, skipping test.");
 		return FWTS_OK;
 	}
@@ -1770,7 +1770,7 @@ static int fadt_test2(fwts_framework *fw)
 
 static int fadt_test3(fwts_framework *fw)
 {
-	if (fwts_acpi_is_reduced_hardware(fadt)) {
+	if (fwts_acpi_is_reduced_hardware(fw)) {
 		fwts_skipped(fw, "In reduced hardware mode, skipping test.");
 		return FWTS_OK;
 	}

--- a/src/acpi/fadt/fadt.c
+++ b/src/acpi/fadt/fadt.c
@@ -425,7 +425,7 @@ static void acpi_table_check_fadt_pm_profile(fwts_framework *fw)
 {
 	fwts_log_info(fw, "FADT Preferred PM Profile: %hhu (%s)",
 		fadt->preferred_pm_profile,
-		FWTS_ACPI_FADT_PREFERRED_PM_PROFILE(fadt->preferred_pm_profile));
+		fwts_acpi_fadt_preferred_pm_profile(fadt->preferred_pm_profile));
 
 	if (fadt->preferred_pm_profile <= 8)
 		fwts_passed(fw, "FADT has a valid preferred PM profile.");

--- a/src/acpi/fadt/fadt.c
+++ b/src/acpi/fadt/fadt.c
@@ -1527,21 +1527,23 @@ static void acpi_table_check_fadt_x_gpex_blk(fwts_framework *fw) {
 	if (fadt->x_gpe0_blk.access_width == 1)
 		fwts_passed(fw, "FADT X_GPE0_BLK has correct byte access width.");
 	else {
-		fwts_failed(fw, LOG_LEVEL_HIGH,
-			"X_GPE0_BLKBadAccessWidth",
-			"FADT X_GPE0_BLK Access width 0x%2.2" PRIx8
-			" but it should be 1 (byte access).",
-			fadt->x_gpe0_blk.access_width);
+		if (!fwts_acpi_data_zero((const void *) &fadt->x_gpe0_blk, sizeof(fwts_acpi_gas)))
+			fwts_failed(fw, LOG_LEVEL_HIGH,
+				"X_GPE0_BLKBadAccessWidth",
+				"FADT X_GPE0_BLK Access width 0x%2.2" PRIx8
+				" but it should be 1 (byte access).",
+				fadt->x_gpe0_blk.access_width);
 	}
 
 	if (fadt->x_gpe1_blk.access_width == 1)
 		fwts_passed(fw, "FADT X_GPE1_BLK has correct byte access width.");
 	else {
-		fwts_failed(fw, LOG_LEVEL_HIGH,
-			"X_GPE1_BLKBadAccessWidth",
-			"FADT X_GPE1_BLK Access width 0x%2.2" PRIx8
-			" but it should be 1 (byte access).",
-			fadt->x_gpe1_blk.access_width);
+		if (!fwts_acpi_data_zero((const void *) &fadt->x_gpe1_blk, sizeof(fwts_acpi_gas)))
+			fwts_failed(fw, LOG_LEVEL_HIGH,
+				"X_GPE1_BLKBadAccessWidth",
+				"FADT X_GPE1_BLK Access width 0x%2.2" PRIx8
+				" but it should be 1 (byte access).",
+				fadt->x_gpe1_blk.access_width);
 	}
 }
 

--- a/src/acpi/fan/fan.c
+++ b/src/acpi/fan/fan.c
@@ -215,8 +215,15 @@ static int fan_test2(fwts_framework *fw)
 
 	fwts_list_foreach(item1, fans1) {
 		fan_info *info1 = fwts_list_data(fan_info *, item1);
+
+		if (!info1->type)
+			continue;
+
 		fwts_list_foreach(item2, fans2) {
 			fan_info *info2 = fwts_list_data(fan_info *, item2);
+
+			if (!info2->type)
+				continue;
 
 			if (strcmp(info1->type, "Processor") == 0) {
 				if (strcmp(info1->name, info2->name) == 0) {

--- a/src/acpi/fpdt/fpdt.c
+++ b/src/acpi/fpdt/fpdt.c
@@ -28,21 +28,7 @@
 #include <ctype.h>
 
 static fwts_acpi_table_info *table;
-
-static int fpdt_init(fwts_framework *fw)
-{
-
-	if (fwts_acpi_find_table(fw, "FPDT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI FPDT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(FPDT, &table)
 
 static void fpdt_rec_header_dump(
 	fwts_framework *fw,
@@ -219,7 +205,7 @@ static fwts_framework_minor_test fpdt_tests[] = {
 
 static fwts_framework_ops fpdt_ops = {
 	.description = "FPDT Firmware Performance Data Table test.",
-	.init        = fpdt_init,
+	.init        = FPDT_init,
 	.minor_tests = fpdt_tests
 };
 

--- a/src/acpi/hest/hest.c
+++ b/src/acpi/hest/hest.c
@@ -27,21 +27,7 @@
 #include <string.h>
 
 static fwts_acpi_table_info *table;
-
-static int hest_init(fwts_framework *fw)
-{
-
-	if (fwts_acpi_find_table(fw, "HEST", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI HEST table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(HEST, &table)
 
 /*
  *  ACPI Section 18.3.2.1 IA-32 Architecture Machine Check Exception
@@ -900,7 +886,7 @@ static fwts_framework_minor_test hest_tests[] = {
 
 static fwts_framework_ops hest_ops = {
 	.description = "HEST Hardware Error Source Table test.",
-	.init        = hest_init,
+	.init        = HEST_init,
 	.minor_tests = hest_tests
 };
 

--- a/src/acpi/hmat/hmat.c
+++ b/src/acpi/hmat/hmat.c
@@ -24,20 +24,7 @@
 #include <stdbool.h>
 
 static fwts_acpi_table_info *table;
-
-static int hmat_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "HMAT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot load ACPI table");
-		return FWTS_ERROR;
-	}
-	if (table == NULL) {
-		fwts_log_error(fw, "ACPI HMAT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(HMAT, &table)
 
 static void hmat_proximity_domain_test(fwts_framework *fw, const fwts_acpi_table_hmat_proximity_domain *entry, bool *passed)
 {
@@ -231,7 +218,7 @@ static fwts_framework_minor_test hmat_tests[] = {
 
 static fwts_framework_ops hmat_ops = {
 	.description = "HMAT Heterogeneous Memory Attribute Table test.",
-	.init        = hmat_init,
+	.init        = HMAT_init,
 	.minor_tests = hmat_tests
 };
 

--- a/src/acpi/iort/iort.c
+++ b/src/acpi/iort/iort.c
@@ -27,21 +27,7 @@
 #include <string.h>
 
 static fwts_acpi_table_info *table;
-
-static int iort_init(fwts_framework *fw)
-{
-
-	if (fwts_acpi_find_table(fw, "IORT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI IORT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(IORT, &table)
 
 /*
  *  iort_node_dump()
@@ -734,7 +720,7 @@ static fwts_framework_minor_test iort_tests[] = {
 
 static fwts_framework_ops iort_ops = {
 	.description = "IORT IO Remapping Table test.",
-	.init        = iort_init,
+	.init        = IORT_init,
 	.minor_tests = iort_tests
 };
 

--- a/src/acpi/lpit/lpit.c
+++ b/src/acpi/lpit/lpit.c
@@ -18,7 +18,7 @@
  */
 #include "fwts.h"
 
-#if defined(FWTS_HAS_ACPI)
+#if defined(FWTS_HAS_ACPI) && !(FWTS_ARCH_AARCH64)
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/acpi/lpit/lpit.c
+++ b/src/acpi/lpit/lpit.c
@@ -27,21 +27,7 @@
 #include <string.h>
 
 static fwts_acpi_table_info *table;
-
-static int lpit_init(fwts_framework *fw)
-{
-
-	if (fwts_acpi_find_table(fw, "LPIT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI LPIT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(LPIT, &table)
 
 static void lpit_check_type_0(
 	fwts_framework *fw,
@@ -231,7 +217,7 @@ static fwts_framework_minor_test lpit_tests[] = {
 
 static fwts_framework_ops lpit_ops = {
 	.description = "LPIT Low Power Idle Table test.",
-	.init        = lpit_init,
+	.init        = LPIT_init,
 	.minor_tests = lpit_tests
 };
 

--- a/src/acpi/mcfg/mcfg.c
+++ b/src/acpi/mcfg/mcfg.c
@@ -27,6 +27,7 @@
 
 static fwts_list *memory_map_list;
 static fwts_acpi_table_info *mcfg_table;
+acpi_table_init(MCFG, &mcfg_table)
 
 static int compare_config_space(
 	fwts_framework *fw,
@@ -93,22 +94,6 @@ static int compare_config_space(
 		fwts_failed(fw, LOG_LEVEL_MEDIUM,
 			"PCIConfigSpaceBad",
 			"PCI config space appears to not work.");
-
-	return FWTS_OK;
-}
-
-static int mcfg_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "MCFG", 0, &mcfg_table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot load ACPI table");
-		return FWTS_ERROR;
-	}
-	if (mcfg_table == NULL) {
-		fwts_log_error(fw,
-			"ACPI table MCFG not found. This table is "
-			"required to check for PCI Express*");
-		return FWTS_ERROR;
-	}
 
 	return FWTS_OK;
 }
@@ -260,7 +245,7 @@ static fwts_framework_minor_test mcfg_tests[] = {
 
 static fwts_framework_ops mcfg_ops = {
 	.description = "MCFG PCI Express* memory mapped config space test.",
-	.init        = mcfg_init,
+	.init        = MCFG_init,
 	.deinit      = mcfg_deinit,
 	.minor_tests = mcfg_tests
 };

--- a/src/acpi/mcfg/mcfg.c
+++ b/src/acpi/mcfg/mcfg.c
@@ -18,8 +18,6 @@
  */
 #include "fwts.h"
 
-#ifdef FWTS_ARCH_INTEL
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -269,4 +267,3 @@ static fwts_framework_ops mcfg_ops = {
 
 FWTS_REGISTER("mcfg", &mcfg_ops, FWTS_TEST_ANYTIME, FWTS_FLAG_BATCH | FWTS_FLAG_ROOT_PRIV | FWTS_FLAG_TEST_ACPI)
 
-#endif

--- a/src/acpi/mchi/mchi.c
+++ b/src/acpi/mchi/mchi.c
@@ -29,21 +29,7 @@
 #define DUMP_MCHI_TABLE		(1)	/* table is small and not used much, so dump it */
 
 static fwts_acpi_table_info *table;
-
-static int mchi_init(fwts_framework *fw)
-{
-
-	if (fwts_acpi_find_table(fw, "MCHI", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI MCHI table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(MCHI, &table)
 
 /*
  *  MCHI Management Controller Host Interface Table
@@ -225,7 +211,7 @@ static fwts_framework_minor_test mchi_tests[] = {
 
 static fwts_framework_ops mchi_ops = {
 	.description = "MCHI Management Controller Host Interface Table test.",
-	.init        = mchi_init,
+	.init        = MCHI_init,
 	.minor_tests = mchi_tests
 };
 

--- a/src/acpi/method/method.c
+++ b/src/acpi/method/method.c
@@ -262,6 +262,9 @@
  * _WED 	 N
  */
 
+#define DEVICE_D3HOT	3
+#define DEVICE_D3COLD	4
+
 static bool fadt_mobile_platform;	/* True if a mobile platform */
 
 #define method_test_integer(name, type)				\
@@ -1570,7 +1573,7 @@ static int method_test_PSW(fwts_framework *fw)
 #define method_test_SxD(name)						\
 static int method_test ## name(fwts_framework *fw)			\
 {									\
-	uint64_t max = 3;						\
+	uint64_t max = DEVICE_D3HOT;					\
 	return method_evaluate_method(fw, METHOD_OPTIONAL,		\
 		# name, NULL, 0, fwts_method_test_integer_max_return, &max);	\
 }
@@ -1583,7 +1586,7 @@ method_test_SxD(_S4D)
 #define method_test_SxW(name)						\
 static int method_test ## name(fwts_framework *fw)			\
 {									\
-	uint64_t max = 4;						\
+	uint64_t max = DEVICE_D3COLD;					\
 	return method_evaluate_method(fw, METHOD_OPTIONAL,		\
 		# name, NULL, 0, fwts_method_test_integer_max_return, &max);	\
 }

--- a/src/acpi/method/method.c
+++ b/src/acpi/method/method.c
@@ -1865,7 +1865,7 @@ static void method_test_CPC_return(
 		fwts_failed(fw, LOG_LEVEL_HIGH,
 			"Method_CPCBadRevision",
 			"_CPC's revision is incorrect, "
-			"expecting 1 ,2 or 3, got 0x%" PRIx8 , revision);
+			"expecting 1, 2 or 3, got 0x%" PRIx8 , revision);
 
 		return;
 	}
@@ -2785,14 +2785,8 @@ static void method_test_LPI_return(
 			}
 
 			if (i == 0) {
-				if (obj->Package.Elements[i].Integer.Value != 0) {
-					fwts_failed(fw, LOG_LEVEL_HIGH,
-						"Method_LPIBadRevision",
-						"%s: Expected Revision to be 0, "
-						"got 0x%4.4" PRIx64 ".", name,
-						(uint64_t)obj->Package.Elements[i].Integer.Value);
+				if (fwts_method_test_revision(fw, name, obj->Package.Elements[i].Integer.Value, 0) != FWTS_OK)
 					failed = true;
-				}
 			} else if (i == 2) {
 				if (obj->Package.Elements[i].Integer.Value != obj->Package.Count - 3) {
 					fwts_failed(fw, LOG_LEVEL_HIGH,
@@ -4470,12 +4464,8 @@ static void method_test_FPS_return(
 		return;
 
 	if (obj->Package.Elements[0].Type == ACPI_TYPE_INTEGER) {
-		if (obj->Package.Elements[0].Integer.Value != 0) {
-			fwts_failed(fw, LOG_LEVEL_MEDIUM,
-				"Method_FPSBadRevision",
-				"%s element 0 is not revision 0.", name);
+		if (fwts_method_test_revision(fw, name, obj->Package.Elements[0].Integer.Value, 0) != FWTS_OK)
 			failed = true;
-		}
 	} else {
 		fwts_failed(fw, LOG_LEVEL_MEDIUM,
 			"Method_FPSBadReturnType",
@@ -4683,12 +4673,8 @@ static void method_test_ART_return(
 		return;
 
 	if (obj->Package.Elements[0].Type == ACPI_TYPE_INTEGER) {
-		if (obj->Package.Elements[0].Integer.Value != 0) {
-			fwts_failed(fw, LOG_LEVEL_MEDIUM,
-				"Method_ARTBadRevision",
-				"%s element 0 is not revision 0.", name);
+		if (fwts_method_test_revision(fw, name, obj->Package.Elements[0].Integer.Value, 0) != FWTS_OK)
 			failed = true;
-		}
 	} else {
 		fwts_failed(fw, LOG_LEVEL_MEDIUM,
 			"Method_ARTBadReturnType",

--- a/src/acpi/method/method.c
+++ b/src/acpi/method/method.c
@@ -1583,7 +1583,7 @@ method_test_SxD(_S4D)
 #define method_test_SxW(name)						\
 static int method_test ## name(fwts_framework *fw)			\
 {									\
-	uint64_t max = 3;						\
+	uint64_t max = 4;						\
 	return method_evaluate_method(fw, METHOD_OPTIONAL,		\
 		# name, NULL, 0, fwts_method_test_integer_max_return, &max);	\
 }

--- a/src/acpi/mpst/mpst.c
+++ b/src/acpi/mpst/mpst.c
@@ -24,20 +24,7 @@
 #include <stdbool.h>
 
 static fwts_acpi_table_info *table;
-
-static int mpst_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "MPST", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot load ACPI table");
-		return FWTS_ERROR;
-	}
-	if (table == NULL) {
-		fwts_log_error(fw, "ACPI MPST table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(MPST, &table)
 
 static int mpst_test1(fwts_framework *fw)
 {
@@ -197,7 +184,7 @@ static fwts_framework_minor_test mpst_tests[] = {
 
 static fwts_framework_ops mpst_ops = {
 	.description = "MPST Memory Power State Table test.",
-	.init        = mpst_init,
+	.init        = MPST_init,
 	.minor_tests = mpst_tests
 };
 

--- a/src/acpi/msct/msct.c
+++ b/src/acpi/msct/msct.c
@@ -26,19 +26,7 @@
 #include <ctype.h>
 
 static fwts_acpi_table_info *table;
-
-static int msct_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "MSCT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI MSCT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-	return FWTS_OK;
-}
+acpi_table_init(MSCT, &table)
 
 /*
  *  MSCT Maximum System Characteristics Table
@@ -127,7 +115,7 @@ static fwts_framework_minor_test msct_tests[] = {
 
 static fwts_framework_ops msct_ops = {
 	.description = "MSCT Maximum System Characteristics Table test.",
-	.init        = msct_init,
+	.init        = MSCT_init,
 	.minor_tests = msct_tests
 };
 

--- a/src/acpi/msdm/msdm.c
+++ b/src/acpi/msdm/msdm.c
@@ -18,7 +18,7 @@
  */
 #include "fwts.h"
 
-#if defined(FWTS_HAS_ACPI)
+#if defined(FWTS_HAS_ACPI) && !(FWTS_ARCH_AARCH64)
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/acpi/msdm/msdm.c
+++ b/src/acpi/msdm/msdm.c
@@ -28,21 +28,7 @@
 #include <ctype.h>
 
 static fwts_acpi_table_info *table;
-
-static int msdm_init(fwts_framework *fw)
-{
-
-	if (fwts_acpi_find_table(fw, "MSDM", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI MSDM table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(MSDM, &table)
 
 /*
  *  Microsoft Data Management (MSDM) Table
@@ -149,7 +135,7 @@ static fwts_framework_minor_test msdm_tests[] = {
 
 static fwts_framework_ops msdm_ops = {
 	.description = "MSDM Microsoft Data Management Table test.",
-	.init        = msdm_init,
+	.init        = MSDM_init,
 	.minor_tests = msdm_tests
 };
 

--- a/src/acpi/nfit/nfit.c
+++ b/src/acpi/nfit/nfit.c
@@ -56,6 +56,7 @@ static const uint8_t guid_virtual_device[4][16] = {
 };
 
 static fwts_acpi_table_info *nfit_table;
+acpi_table_init(NFIT, &nfit_table)
 
 static bool check_length(fwts_framework *fw, const int actual, int min, const char *name)
 {
@@ -109,19 +110,6 @@ static bool scan_nfit_smbios(fwts_framework *fw, int len, uint8_t *table)
 		return false;
 	}
 	return true;
-}
-
-static int nfit_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "NFIT", 0, &nfit_table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (nfit_table == NULL || (nfit_table && nfit_table->length == 0)) {
-		fwts_log_error(fw, "ACPI NFIT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-	return FWTS_OK;
 }
 
 /*
@@ -543,7 +531,7 @@ static fwts_framework_minor_test nfit_tests[] = {
 
 static fwts_framework_ops nfit_ops = {
 	.description = "NFIT NVDIMM Firmware Interface Table test.",
-	.init        = nfit_init,
+	.init        = NFIT_init,
 	.minor_tests = nfit_tests
 };
 

--- a/src/acpi/pcct/pcct.c
+++ b/src/acpi/pcct/pcct.c
@@ -24,20 +24,7 @@
 #include <stdbool.h>
 
 static fwts_acpi_table_info *table;
-
-static int pcct_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "PCCT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot load ACPI table");
-		return FWTS_ERROR;
-	}
-	if (table == NULL) {
-		fwts_log_error(fw, "ACPI PCCT table does not exist, skipping test");
-		return FWTS_ERROR;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(PCCT, &table)
 
 static bool subspace_length_equal(fwts_framework *fw, uint8_t type, uint8_t type_size, uint8_t length)
 {
@@ -315,7 +302,7 @@ static fwts_framework_minor_test pcct_tests[] = {
 
 static fwts_framework_ops pcct_ops = {
 	.description = "PCCT Platform Communications Channel test.",
-	.init        = pcct_init,
+	.init        = PCCT_init,
 	.minor_tests = pcct_tests
 };
 

--- a/src/acpi/pdtt/pdtt.c
+++ b/src/acpi/pdtt/pdtt.c
@@ -24,20 +24,7 @@
 #include <stdbool.h>
 
 static fwts_acpi_table_info *table;
-
-static int pdtt_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "PDTT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot load ACPI table");
-		return FWTS_ERROR;
-	}
-	if (table == NULL) {
-		fwts_log_error(fw, "ACPI PDTT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(PDTT, &table)
 
 static int pdtt_test1(fwts_framework *fw)
 {
@@ -103,7 +90,7 @@ static fwts_framework_minor_test pdtt_tests[] = {
 
 static fwts_framework_ops pdtt_ops = {
 	.description = "PDTT Platform Debug Trigger Table test.",
-	.init        = pdtt_init,
+	.init        = PDTT_init,
 	.minor_tests = pdtt_tests
 };
 

--- a/src/acpi/pmtt/pmtt.c
+++ b/src/acpi/pmtt/pmtt.c
@@ -24,20 +24,7 @@
 #include <stdbool.h>
 
 static fwts_acpi_table_info *table;
-
-static int pmtt_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "PMTT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot load ACPI table");
-		return FWTS_ERROR;
-	}
-	if (table == NULL) {
-		fwts_log_error(fw, "ACPI PMTT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(PMTT, &table)
 
 static void pmtt_subtable_header_test(fwts_framework *fw, fwts_acpi_table_pmtt_header *entry, bool *passed)
 {
@@ -222,7 +209,7 @@ static fwts_framework_minor_test pmtt_tests[] = {
 
 static fwts_framework_ops pmtt_ops = {
 	.description = "PMTT Memory Topology Table test.",
-	.init        = pmtt_init,
+	.init        = PMTT_init,
 	.minor_tests = pmtt_tests
 };
 

--- a/src/acpi/pptt/pptt.c
+++ b/src/acpi/pptt/pptt.c
@@ -24,20 +24,7 @@
 #include <stdbool.h>
 
 static fwts_acpi_table_info *table;
-
-static int pptt_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "PPTT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot load ACPI table");
-		return FWTS_ERROR;
-	}
-	if (table == NULL) {
-		fwts_log_error(fw, "ACPI PPTT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(PPTT, &table)
 
 static void pptt_processor_test(fwts_framework *fw, const fwts_acpi_table_pptt_processor *entry, uint8_t rev, bool *passed)
 {
@@ -191,7 +178,7 @@ static fwts_framework_minor_test pptt_tests[] = {
 
 static fwts_framework_ops pptt_ops = {
 	.description = "PPTT Processor Properties Topology Table test.",
-	.init        = pptt_init,
+	.init        = PPTT_init,
 	.minor_tests = pptt_tests
 };
 

--- a/src/acpi/rasf/rasf.c
+++ b/src/acpi/rasf/rasf.c
@@ -27,20 +27,7 @@
 #include <string.h>
 
 static fwts_acpi_table_info *table;
-
-static int rasf_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "RASF", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI RASF table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(RASF, &table)
 
 static int rasf_test1(fwts_framework *fw)
 {
@@ -73,7 +60,7 @@ static fwts_framework_minor_test rasf_tests[] = {
 
 static fwts_framework_ops rasf_ops = {
 	.description = "RASF RAS Feature Table test",
-	.init        = rasf_init,
+	.init        = RASF_init,
 	.minor_tests = rasf_tests
 };
 

--- a/src/acpi/rsdt/rsdt.c
+++ b/src/acpi/rsdt/rsdt.c
@@ -27,19 +27,7 @@
 #include <string.h>
 
 static fwts_acpi_table_info *table;
-
-static int rsdt_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "RSDT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI RSDT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-	return FWTS_OK;
-}
+acpi_table_init(RSDT, &table)
 
 /*
  *  RSDT Extended System Description Table
@@ -78,7 +66,7 @@ static fwts_framework_minor_test rsdt_tests[] = {
 
 static fwts_framework_ops rsdt_ops = {
 	.description = "RSDT Root System Description Table test.",
-	.init        = rsdt_init,
+	.init        = RSDT_init,
 	.minor_tests = rsdt_tests
 };
 

--- a/src/acpi/rsdt/rsdt.c
+++ b/src/acpi/rsdt/rsdt.c
@@ -18,7 +18,7 @@
  */
 #include "fwts.h"
 
-#if defined(FWTS_HAS_ACPI)
+#if defined(FWTS_HAS_ACPI) && !(FWTS_ARCH_AARCH64)
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/acpi/sbst/sbst.c
+++ b/src/acpi/sbst/sbst.c
@@ -27,19 +27,7 @@
 #include <string.h>
 
 static fwts_acpi_table_info *table;
-
-static int sbst_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "SBST", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI SBST table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-	return FWTS_OK;
-}
+acpi_table_init(SBST,&table)
 
 /*
  *  SBST Extended System Description Table
@@ -88,7 +76,7 @@ static fwts_framework_minor_test sbst_tests[] = {
 
 static fwts_framework_ops sbst_ops = {
 	.description = "SBST Smart Battery Specification Table test.",
-	.init        = sbst_init,
+	.init        = SBST_init,
 	.minor_tests = sbst_tests
 };
 

--- a/src/acpi/sdei/sdei.c
+++ b/src/acpi/sdei/sdei.c
@@ -27,20 +27,7 @@
 #include <string.h>
 
 static fwts_acpi_table_info *table;
-
-static int sdei_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "SDEI", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI SDEI table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(SDEI, &table)
 
 static int sdei_test1(fwts_framework *fw)
 {
@@ -77,7 +64,7 @@ static fwts_framework_minor_test sdei_tests[] = {
 
 static fwts_framework_ops sdei_ops = {
 	.description = "SDEI Software Delegated Exception Interface Table test",
-	.init        = sdei_init,
+	.init        = SDEI_init,
 	.minor_tests = sdei_tests
 };
 

--- a/src/acpi/sdev/sdev.c
+++ b/src/acpi/sdev/sdev.c
@@ -27,20 +27,7 @@
 #include <string.h>
 
 static fwts_acpi_table_info *table;
-
-static int sdev_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "SDEV", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI SDEV table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(SDEV, &table)
 
 static void sdev_acpi_namespace_device_test(fwts_framework *fw, const fwts_acpi_table_sdev_acpi *entry, bool *passed)
 {
@@ -137,7 +124,7 @@ static fwts_framework_minor_test sdev_tests[] = {
 
 static fwts_framework_ops sdev_ops = {
 	.description = "SDEV Secure Devices Table test",
-	.init        = sdev_init,
+	.init        = SDEV_init,
 	.minor_tests = sdev_tests
 };
 

--- a/src/acpi/slic/slic.c
+++ b/src/acpi/slic/slic.c
@@ -18,7 +18,7 @@
  */
 #include "fwts.h"
 
-#if defined(FWTS_HAS_ACPI)
+#if defined(FWTS_HAS_ACPI) && !(FWTS_ARCH_AARCH64)
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/acpi/slic/slic.c
+++ b/src/acpi/slic/slic.c
@@ -29,21 +29,7 @@
 #define	DUMP_SLIC	(0)	/* Disable this, just used it for debugging */
 
 static fwts_acpi_table_info *table;
-
-static int slic_init(fwts_framework *fw)
-{
-
-	if (fwts_acpi_find_table(fw, "SLIC", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI SLIC table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(SLIC, &table)
 
 /*
  *  Software Licensing Description Table
@@ -170,7 +156,7 @@ static fwts_framework_minor_test slic_tests[] = {
 
 static fwts_framework_ops slic_ops = {
 	.description = "SLIC Software Licensing Description Table test.",
-	.init        = slic_init,
+	.init        = SLIC_init,
 	.minor_tests = slic_tests
 };
 

--- a/src/acpi/slit/slit.c
+++ b/src/acpi/slit/slit.c
@@ -29,21 +29,7 @@
 #define	INDEX(i, j)	(((i) * slit->num_of_system_localities) + (j))
 
 static fwts_acpi_table_info *table;
-
-static int slit_init(fwts_framework *fw)
-{
-
-	if (fwts_acpi_find_table(fw, "SLIT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI SLIT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(SLIT, &table)
 
 /*
  *  For SLIT System Locality Distance Information refer to
@@ -178,7 +164,7 @@ static fwts_framework_minor_test slit_tests[] = {
 
 static fwts_framework_ops slit_ops = {
 	.description = "SLIT System Locality Distance Information test.",
-	.init        = slit_init,
+	.init        = SLIT_init,
 	.minor_tests = slit_tests
 };
 

--- a/src/acpi/spmi/spmi.c
+++ b/src/acpi/spmi/spmi.c
@@ -27,21 +27,7 @@
 #include <string.h>
 
 static fwts_acpi_table_info *table;
-
-static int spmi_init(fwts_framework *fw)
-{
-
-	if (fwts_acpi_find_table(fw, "SPMI", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI SPMI table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(SPMI, &table)
 
 /*
  *  SPMI Service Processor Management Interface Description Table
@@ -218,7 +204,7 @@ static fwts_framework_minor_test spmi_tests[] = {
 
 static fwts_framework_ops spmi_ops = {
 	.description = "SPMI Service Processor Management Interface Description Table test.",
-	.init        = spmi_init,
+	.init        = SPMI_init,
 	.minor_tests = spmi_tests
 };
 

--- a/src/acpi/srat/srat.c
+++ b/src/acpi/srat/srat.c
@@ -27,21 +27,7 @@
 #include <string.h>
 
 static fwts_acpi_table_info *table;
-
-static int srat_init(fwts_framework *fw)
-{
-
-	if (fwts_acpi_find_table(fw, "SRAT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI SRAT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(SRAT, &table)
 
 static void srat_check_local_apic_sapic_affinity(
 	fwts_framework *fw,
@@ -417,7 +403,7 @@ static fwts_framework_minor_test srat_tests[] = {
 
 static fwts_framework_ops srat_ops = {
 	.description = "SRAT System Resource Affinity Table test.",
-	.init        = srat_init,
+	.init        = SRAT_init,
 	.minor_tests = srat_tests
 };
 

--- a/src/acpi/stao/stao.c
+++ b/src/acpi/stao/stao.c
@@ -29,21 +29,7 @@
 #include "fwts_acpi_object_eval.h"
 
 static fwts_acpi_table_info *table;
-
-static int stao_init(fwts_framework *fw)
-{
-
-	if (fwts_acpi_find_table(fw, "STAO", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI STAO table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(STAO, &table)
 
 /*
  *  Extract a STAO ACPI String from the raw buffer
@@ -154,7 +140,7 @@ static fwts_framework_minor_test stao_tests[] = {
 
 static fwts_framework_ops stao_ops = {
 	.description = "STAO Status Override Table test.",
-	.init        = stao_init,
+	.init        = STAO_init,
 	.minor_tests = stao_tests
 };
 

--- a/src/acpi/tcpa/tcpa.c
+++ b/src/acpi/tcpa/tcpa.c
@@ -24,20 +24,7 @@
 #include <stdbool.h>
 
 static fwts_acpi_table_info *table;
-
-static int tcpa_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "TCPA", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot load ACPI table");
-		return FWTS_ERROR;
-	}
-	if (table == NULL) {
-		fwts_log_error(fw, "ACPI TCPA table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(TCPA, &table)
 
 static int tcpa_client_test(fwts_framework *fw, fwts_acpi_table_tcpa *tcpa)
 {
@@ -202,7 +189,7 @@ static fwts_framework_minor_test tcpa_tests[] = {
 
 static fwts_framework_ops tcpa_ops = {
 	.description = "TCPA Trusted Computing Platform Alliance Capabilities Table test.",
-	.init        = tcpa_init,
+	.init        = TCPA_init,
 	.minor_tests = tcpa_tests
 };
 

--- a/src/acpi/tpm2/tpm2.c
+++ b/src/acpi/tpm2/tpm2.c
@@ -24,20 +24,7 @@
 #include <stdbool.h>
 
 static fwts_acpi_table_info *table;
-
-static int tpm2_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "TPM2", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot load ACPI table");
-		return FWTS_ERROR;
-	}
-	if (table == NULL) {
-		fwts_log_error(fw, "ACPI TPM2 table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(TPM2, &table)
 
 /*
  * TPM2 table
@@ -106,7 +93,7 @@ static fwts_framework_minor_test tpm2_tests[] = {
 
 static fwts_framework_ops tpm2_ops = {
 	.description = "TPM2 Trusted Platform Module 2 test.",
-	.init        = tpm2_init,
+	.init        = TPM2_init,
 	.minor_tests = tpm2_tests
 };
 

--- a/src/acpi/uefi/uefi.c
+++ b/src/acpi/uefi/uefi.c
@@ -28,19 +28,7 @@
 #include <ctype.h>
 
 static fwts_acpi_table_info *table;
-
-static int uefi_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "UEFI", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI UEFI table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-	return FWTS_OK;
-}
+acpi_table_init(UEFI, &table)
 
 /*
  *  UEFI ACPI DATA Table
@@ -123,7 +111,7 @@ static fwts_framework_minor_test uefi_tests[] = {
 
 static fwts_framework_ops uefi_ops = {
 	.description = "UEFI Data Table test.",
-	.init        = uefi_init,
+	.init        = UEFI_init,
 	.minor_tests = uefi_tests
 };
 

--- a/src/acpi/waet/waet.c
+++ b/src/acpi/waet/waet.c
@@ -18,7 +18,7 @@
  */
 #include "fwts.h"
 
-#if defined(FWTS_HAS_ACPI)
+#if defined(FWTS_HAS_ACPI) && !(FWTS_ARCH_AARCH64)
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/acpi/waet/waet.c
+++ b/src/acpi/waet/waet.c
@@ -30,20 +30,7 @@
 #include "fwts_acpi_object_eval.h"
 
 static fwts_acpi_table_info *table;
-
-static int waet_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "WAET", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI WAET table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(WAET, &table)
 
 /*
  *  WAET Windows ACPI Emulated Devices Table
@@ -82,7 +69,7 @@ static fwts_framework_minor_test waet_tests[] = {
 
 static fwts_framework_ops waet_ops = {
 	.description = "WAET Windows ACPI Emulated Devices Table test.",
-	.init        = waet_init,
+	.init        = WAET_init,
 	.minor_tests = waet_tests
 };
 

--- a/src/acpi/wdat/wdat.c
+++ b/src/acpi/wdat/wdat.c
@@ -18,7 +18,7 @@
  */
 #include "fwts.h"
 
-#if defined(FWTS_HAS_ACPI)
+#if defined(FWTS_HAS_ACPI) && !(FWTS_ARCH_AARCH64)
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/acpi/wdat/wdat.c
+++ b/src/acpi/wdat/wdat.c
@@ -31,21 +31,7 @@
 #define ACPI_DUMP	(0)		/* WDAT entries are long, so don't dump, too verbose */
 
 static fwts_acpi_table_info *table;
-
-static int wdat_init(fwts_framework *fw)
-{
-
-	if (fwts_acpi_find_table(fw, "WDAT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI WDAT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(WDAT, &table)
 
 /*
  * ACPI WDAT (Watchdog Action Table)
@@ -213,7 +199,7 @@ static fwts_framework_minor_test wdat_tests[] = {
 
 static fwts_framework_ops wdat_ops = {
 	.description = "WDAT Microsoft Hardware Watchdog Action Table test.",
-	.init        = wdat_init,
+	.init        = WDAT_init,
 	.minor_tests = wdat_tests
 };
 

--- a/src/acpi/wpbt/wpbt.c
+++ b/src/acpi/wpbt/wpbt.c
@@ -18,7 +18,7 @@
  */
 #include "fwts.h"
 
-#if defined(FWTS_HAS_ACPI)
+#if defined(FWTS_HAS_ACPI) && !(FWTS_ARCH_AARCH64)
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/acpi/wpbt/wpbt.c
+++ b/src/acpi/wpbt/wpbt.c
@@ -28,19 +28,7 @@
 #include <ctype.h>
 
 static fwts_acpi_table_info *table;
-
-static int wpbt_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "WPBT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI WPBT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-	return FWTS_OK;
-}
+acpi_table_init(WPBT, &table)
 
 /*
  *  WPBT Windows Platform Binary Table
@@ -99,7 +87,7 @@ static fwts_framework_minor_test wpbt_tests[] = {
 
 static fwts_framework_ops wpbt_ops = {
 	.description = "WPBT Windows Platform Binary Table test.",
-	.init        = wpbt_init,
+	.init        = WPBT_init,
 	.minor_tests = wpbt_tests
 };
 

--- a/src/acpi/wsmt/wsmt.c
+++ b/src/acpi/wsmt/wsmt.c
@@ -28,19 +28,7 @@
 #include <ctype.h>
 
 static fwts_acpi_table_info *table;
-
-static int wsmt_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "WSMT", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot read ACPI tables.");
-		return FWTS_ERROR;
-	}
-	if (table == NULL || (table && table->length == 0)) {
-		fwts_log_error(fw, "ACPI WSMT table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-	return FWTS_OK;
-}
+acpi_table_init(WSMT, &table)
 
 /*
  *  WSMT Windows Platform Binary Table
@@ -78,7 +66,7 @@ static fwts_framework_minor_test wsmt_tests[] = {
 
 static fwts_framework_ops wsmt_ops = {
 	.description = "WSMT Windows SMM Security Mitigations Table test.",
-	.init        = wsmt_init,
+	.init        = WSMT_init,
 	.minor_tests = wsmt_tests
 };
 

--- a/src/acpi/xenv/xenv.c
+++ b/src/acpi/xenv/xenv.c
@@ -24,20 +24,7 @@
 #include <inttypes.h>
 
 static fwts_acpi_table_info *table;
-
-static int xenv_init(fwts_framework *fw)
-{
-	if (fwts_acpi_find_table(fw, "XENV", 0, &table) != FWTS_OK) {
-		fwts_log_error(fw, "Cannot load ACPI table");
-		return FWTS_ERROR;
-	}
-	if (table == NULL) {
-		fwts_log_error(fw, "ACPI XENV table does not exist, skipping test");
-		return FWTS_SKIP;
-	}
-
-	return FWTS_OK;
-}
+acpi_table_init(XENV, &table)
 
 /*
  * Sanity check XENV table, see:
@@ -86,7 +73,7 @@ static fwts_framework_minor_test xenv_tests[] = {
 
 static fwts_framework_ops xenv_check_ops = {
 	.description = "XENV Xen Environment Table tests.",
-	.init        = xenv_init,
+	.init        = XENV_init,
 	.minor_tests = xenv_tests
 };
 

--- a/src/acpica/source/common/ahuuids.c
+++ b/src/acpica/source/common/ahuuids.c
@@ -181,6 +181,7 @@ const AH_UUID  Gbl_AcpiUuids[] =
     {"Physical Presence Interface", UUID_PHYSICAL_PRESENCE},
 
     {"[Non-volatile DIMM and NFIT table]",       NULL},
+    {"NVDIMM Device",               UUID_NFIT_DIMM},
     {"Volatile Memory Region",      UUID_VOLATILE_MEMORY},
     {"Persistent Memory Region",    UUID_PERSISTENT_MEMORY},
     {"NVDIMM Control Region",       UUID_CONTROL_REGION},
@@ -189,6 +190,10 @@ const AH_UUID  Gbl_AcpiUuids[] =
     {"Volatile Virtual CD",         UUID_VOLATILE_VIRTUAL_CD},
     {"Persistent Virtual Disk",     UUID_PERSISTENT_VIRTUAL_DISK},
     {"Persistent Virtual CD",       UUID_PERSISTENT_VIRTUAL_CD},
+    {"Microsoft NVDIMM Command set",UUID_NFIT_DIMM_N_MSFT},
+    {"HP NDIMM HPE1",               UUID_NFIT_DIMM_N_HPE1},
+    {"HP NDIMM HPE2",               UUID_NFIT_DIMM_N_HPE2},
+    {"Virtual NVDIMM",              UUID_NFIT_DIMM_N_HYPERV},
 
     {"[Processor Properties]",      NULL},
     {"Cache Properties",            UUID_CACHE_PROPERTIES},

--- a/src/acpica/source/compiler/aslanalyze.c
+++ b/src/acpica/source/compiler/aslanalyze.c
@@ -470,7 +470,7 @@ AnCheckMethodReturnValue (
                 "Method returns [%s], %s operator requires [%s]",
                 AslGbl_StringBuffer, OpInfo->Name, AslGbl_StringBuffer2);
 
-            AslError (ASL_ERROR, ASL_MSG_INVALID_TYPE, ArgOp, AslGbl_MsgBuffer);
+            AslError (ASL_WARNING, ASL_MSG_INVALID_TYPE, ArgOp, AslGbl_MsgBuffer);
         }
     }
 

--- a/src/acpica/source/compiler/aslbtypes.c
+++ b/src/acpica/source/compiler/aslbtypes.c
@@ -672,7 +672,7 @@ AnMapObjTypeToBtype (
  *
  * PARAMETERS:  Btype               - Bitfield of ACPI types
  *
- * RETURN:      The Etype corresponding the the Btype
+ * RETURN:      The Etype corresponding the Btype
  *
  * DESCRIPTION: Convert a bitfield type to an encoded type
  *

--- a/src/acpica/source/compiler/aslcodegen.c
+++ b/src/acpica/source/compiler/aslcodegen.c
@@ -700,7 +700,7 @@ CgUpdateHeader (
 
     Checksum = (UINT8) (0 - Sum);
 
-    /* Re-write the the checksum byte */
+    /* Re-write the checksum byte */
 
     FlSeekFile (ASL_FILE_AML_OUTPUT, Op->Asl.FinalAmlOffset +
         ACPI_OFFSET (ACPI_TABLE_HEADER, Checksum));

--- a/src/acpica/source/compiler/aslcompiler.l
+++ b/src/acpica/source/compiler/aslcompiler.l
@@ -812,9 +812,9 @@ NamePathTail                [.]{NameSeg}
 "__PATH__"                  { count (0); return (PARSEOP___PATH__); }
 "__METHOD__"                { count (0); return (PARSEOP___METHOD__); }
 "__EXPECT__"{ErrorCode}     { char *s;
-                                int index = 0;
+                                unsigned int index = 0;
                                 count (0);
-                                while (!isdigit (AslCompilertext[index]))
+                                while (!isdigit ((int) AslCompilertext[index]))
                                 {
                                     index++;
                                 }

--- a/src/acpica/source/compiler/aslerror.c
+++ b/src/acpica/source/compiler/aslerror.c
@@ -1456,7 +1456,7 @@ AslIsExceptionDisabled (
         {
             return (TRUE);
         }
-        /* Fall through */
+        ACPI_FALLTHROUGH;
 
     case ASL_WARNING:
     case ASL_REMARK:

--- a/src/acpica/source/compiler/aslmap.c
+++ b/src/acpica/source/compiler/aslmap.c
@@ -538,7 +538,7 @@ const ASL_MAPPING_ENTRY     AslKeywordMapping [] =
 /* TYPE_TRANSLATION */          OP_TABLE_ENTRY (AML_BYTE_OP,                1,                              0,                  0),
 /* UART_SERIALBUS */            OP_TABLE_ENTRY (AML_DEFAULT_ARG_OP,         0,                              0,                  0),
 /* UART_SERIALBUSV2 */          OP_TABLE_ENTRY (AML_DEFAULT_ARG_OP,         0,                              0,                  0),
-/* UNICODE */                   OP_TABLE_ENTRY (AML_BUFFER_OP,              0,                              OP_AML_PACKAGE,     0),
+/* UNICODE */                   OP_TABLE_ENTRY (AML_BUFFER_OP,              0,                              OP_AML_PACKAGE,     ACPI_BTYPE_BUFFER),
 /* UNLOAD */                    OP_TABLE_ENTRY (AML_UNLOAD_OP,              0,                              0,                  0),
 /* UPDATERULE_ONES */           OP_TABLE_ENTRY (AML_BYTE_OP,                AML_FIELD_UPDATE_WRITE_AS_ONES, 0,                  0),
 /* UPDATERULE_PRESERVE */       OP_TABLE_ENTRY (AML_BYTE_OP,                AML_FIELD_UPDATE_PRESERVE,      0,                  0),

--- a/src/acpica/source/compiler/aslmessages.c
+++ b/src/acpica/source/compiler/aslmessages.c
@@ -384,6 +384,7 @@ const char                      *AslCompilerMsgs [] =
 /*    ASL_MSG_EXTERNAL_FOUND_HERE */        "External declaration below ",
 /*    ASL_MSG_LOWER_CASE_NAMESEG */         "At least one lower case letter found in NameSeg, ASL is case insensitive - converting to upper case",
 /*    ASL_MSG_LOWER_CASE_NAMEPATH */        "At least one lower case letter found in NamePath, ASL is case insensitive - converting to upper case",
+/*    ASL_MSG_UUID_NOT_FOUND */             "Unknown UUID string"
 };
 
 /* Table compiler */
@@ -457,7 +458,7 @@ AeDecodeMessageId (
 
         if (Index >= ACPI_ARRAY_LENGTH (AslCompilerMsgs))
         {
-            return ("[Unknown ASL Compiler exception ID]");
+            return ("[Unknown iASL Compiler exception ID]");
         }
     }
 
@@ -470,7 +471,7 @@ AeDecodeMessageId (
 
         if (Index >= ACPI_ARRAY_LENGTH (AslTableCompilerMsgs))
         {
-            return ("[Unknown Table Compiler exception ID]");
+            return ("[Unknown iASL Table Compiler exception ID]");
         }
     }
 
@@ -483,7 +484,7 @@ AeDecodeMessageId (
 
         if (Index >= ACPI_ARRAY_LENGTH (AslPreprocessorMsgs))
         {
-            return ("[Unknown Preprocessor exception ID]");
+            return ("[Unknown iASL Preprocessor exception ID]");
         }
     }
 
@@ -491,7 +492,7 @@ AeDecodeMessageId (
 
     else
     {
-        return ("[Unknown exception/component ID]");
+        return ("[Unknown iASL exception ID]");
     }
 
     return (MessageTable[Index]);
@@ -559,3 +560,79 @@ AeBuildFullExceptionCode (
      */
     return (((Level + 1) * 1000) + MessageId);
 }
+
+
+#ifdef ACPI_HELP_APP
+/*******************************************************************************
+ *
+ * FUNCTION:    AhDecodeAslException
+ *
+ * PARAMETERS:  HexString           - iASL status string from command line, in
+ *                                    hex. If null, display all exceptions.
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Decode and display an iASL exception code. Note1: a
+ * NULL string for HexString displays all known iASL exceptions. Note2:
+ * implements the -x option for AcpiHelp.
+ *
+ ******************************************************************************/
+
+#define AH_DISPLAY_ASL_EXCEPTION_TEXT(Status, Exception) \
+    printf ("%.4X: %s\n", Status, Exception)
+
+#define AH_DISPLAY_EXCEPTION(Status, Name) \
+    printf ("%.4X: %s\n", Status, Name)
+
+
+void
+AhDecodeAslException (
+    char                    *HexString)
+{
+    UINT32                  i;
+    UINT32                  MessageId;
+    const char              *OneException;
+    UINT32                  Index = 1;
+
+
+    /*
+     * A null input string means to decode and display all known
+     * exception codes.
+     */
+    if (!HexString)
+    {
+        printf ("All defined iASL exception codes:\n\n");
+        printf ("Main iASL exceptions:\n\n");
+        AH_DISPLAY_EXCEPTION (0,
+            "AE_OK                        (No error occurred)");
+
+        /* Display codes in each block of exception types */
+
+        for (i = 1; Index < ACPI_ARRAY_LENGTH (AslCompilerMsgs); i++, Index++)
+        {
+            AH_DISPLAY_ASL_EXCEPTION_TEXT (Index, AslCompilerMsgs[i]);
+        }
+
+        printf ("\niASL Table Compiler exceptions:\n\n");
+        Index = ASL_MSG_TABLE_COMPILER;
+        for (i = 0; i < ACPI_ARRAY_LENGTH (AslTableCompilerMsgs); i++, Index++)
+        {
+            AH_DISPLAY_ASL_EXCEPTION_TEXT (Index, AslTableCompilerMsgs[i]);
+        }
+
+        printf ("\niASL Preprocessor exceptions:\n\n");
+        Index = ASL_MSG_PREPROCESSOR;
+        for (i = 0; i < ACPI_ARRAY_LENGTH (AslPreprocessorMsgs); i++, Index++)
+        {
+            AH_DISPLAY_ASL_EXCEPTION_TEXT (Index, AslPreprocessorMsgs[i]);
+        }
+        return;
+    }
+
+    /* HexString is valid - convert it to a MessageId and decode it */
+
+    MessageId = strtol (HexString, NULL, 16);
+    OneException = AeDecodeMessageId ((UINT16) MessageId);
+    AH_DISPLAY_ASL_EXCEPTION_TEXT (MessageId, OneException);
+}
+#endif

--- a/src/acpica/source/compiler/aslmessages.h
+++ b/src/acpica/source/compiler/aslmessages.h
@@ -152,7 +152,6 @@
 #ifndef __ASLMESSAGES_H
 #define __ASLMESSAGES_H
 
-
 /* These values must match error type string tables in aslmessages.c */
 
 typedef enum
@@ -167,8 +166,11 @@ typedef enum
 
 } ASL_MESSAGE_TYPES;
 
-
 #define ASL_ERROR_LEVEL_LENGTH          8 /* Length of strings for types above */
+
+void
+AhDecodeAslException (
+    char                    *HexString);
 
 /*
  * Exception code blocks, 0 - 999
@@ -386,6 +388,7 @@ typedef enum
     ASL_MSG_EXTERNAL_FOUND_HERE,
     ASL_MSG_LOWER_CASE_NAMESEG,
     ASL_MSG_LOWER_CASE_NAMEPATH,
+    ASL_MSG_UUID_NOT_FOUND,
 
 
     /* These messages are used by the Data Table compiler only */

--- a/src/acpica/source/compiler/aslmethod.c
+++ b/src/acpica/source/compiler/aslmethod.c
@@ -288,6 +288,7 @@ MtMethodAnalysisWalkBegin (
         NextType = Next->Asl.Child;
 
         MethodInfo->ValidReturnTypes = MtProcessTypeOp (NextType);
+        Op->Asl.AcpiBtype |= MethodInfo->ValidReturnTypes;
 
         /* Get the ParameterType node */
 

--- a/src/acpica/source/compiler/aslopcodes.c
+++ b/src/acpica/source/compiler/aslopcodes.c
@@ -798,7 +798,13 @@ OpcDoUuId (
     }
     else
     {
+        /* Convert UUID string to a buffer, check for a known UUID */
+
         AcpiUtConvertStringToUuid (InString, Buffer);
+        if (!AcpiAhMatchUuid (Buffer))
+        {
+            AslError (ASL_REMARK, ASL_MSG_UUID_NOT_FOUND, Op, NULL);
+        }
     }
 
     /* Change Op to a Buffer */

--- a/src/acpica/source/compiler/aslparseop.c
+++ b/src/acpica/source/compiler/aslparseop.c
@@ -414,7 +414,7 @@ TrCreateValuedLeafOp (
 
         for (i = 0; i < ACPI_NAMESEG_SIZE; i++)
         {
-            if (islower (Op->Asl.Value.Name[i]))
+            if (islower ((int) Op->Asl.Value.Name[i]))
             {
                 AcpiUtStrupr (&Op->Asl.Value.Name[i]);
                 AslError (ASL_REMARK, ASL_MSG_LOWER_CASE_NAMESEG, Op, Op->Asl.Value.Name);
@@ -431,7 +431,7 @@ TrCreateValuedLeafOp (
         StringPtr = Op->Asl.Value.Name;
         for (i = 0; *StringPtr; i++)
         {
-            if (islower (*StringPtr))
+            if (islower ((int) *StringPtr))
             {
                 AcpiUtStrupr (&Op->Asl.Value.Name[i]);
                 AslError (ASL_REMARK, ASL_MSG_LOWER_CASE_NAMEPATH, Op, Op->Asl.Value.Name);

--- a/src/acpica/source/compiler/aslprimaries.y
+++ b/src/acpica/source/compiler/aslprimaries.y
@@ -500,7 +500,7 @@ DivideTerm
 EISAIDTerm
     : PARSEOP_EISAID
         PARSEOP_OPEN_PAREN
-        StringData
+        StringLiteral
         PARSEOP_CLOSE_PAREN         {$$ = TrSetOpIntegerValue (PARSEOP_EISAID, $3);}
     | PARSEOP_EISAID
         PARSEOP_OPEN_PAREN
@@ -635,7 +635,7 @@ FprintfTerm
     : PARSEOP_FPRINTF
         PARSEOP_OPEN_PAREN          {$<n>$ = TrCreateLeafOp (PARSEOP_FPRINTF);}
         TermArg ','
-        StringData
+        StringLiteral
         PrintfArgList
         PARSEOP_CLOSE_PAREN         {$$ = TrLinkOpChildren ($<n>3,3,$4,$6,$7);}
     | PARSEOP_FPRINTF
@@ -1091,7 +1091,7 @@ PowerResTerm
 PrintfTerm
     : PARSEOP_PRINTF
         PARSEOP_OPEN_PAREN          {$<n>$ = TrCreateLeafOp (PARSEOP_PRINTF);}
-        StringData
+        StringLiteral
         PrintfArgList
         PARSEOP_CLOSE_PAREN         {$$ = TrLinkOpChildren ($<n>3,2,$4,$5);}
     | PARSEOP_PRINTF
@@ -1412,7 +1412,7 @@ ToStringTerm
 ToUUIDTerm
     : PARSEOP_TOUUID
         PARSEOP_OPEN_PAREN
-        StringData
+        StringLiteral
         PARSEOP_CLOSE_PAREN         {$$ = TrSetOpIntegerValue (PARSEOP_TOUUID, $3);}
     | PARSEOP_TOUUID
         PARSEOP_OPEN_PAREN
@@ -1422,7 +1422,7 @@ ToUUIDTerm
 UnicodeTerm
     : PARSEOP_UNICODE
         PARSEOP_OPEN_PAREN          {$<n>$ = TrCreateLeafOp (PARSEOP_UNICODE);}
-        StringData
+        StringLiteral
         PARSEOP_CLOSE_PAREN         {$$ = TrLinkOpChildren ($<n>3,2,0,$4);}
     | PARSEOP_UNICODE
         PARSEOP_OPEN_PAREN

--- a/src/acpica/source/compiler/aslrules.y
+++ b/src/acpica/source/compiler/aslrules.y
@@ -523,6 +523,10 @@ StringData
     | String                        {}
     ;
 
+StringLiteral
+    : String                        {}
+    ;
+
 ByteConst
     : Integer                       {$$ = TrSetOpIntegerValue (PARSEOP_BYTECONST, $1);}
     ;

--- a/src/acpica/source/compiler/asltypes.y
+++ b/src/acpica/source/compiler/asltypes.y
@@ -178,6 +178,7 @@ NoEcho('
 %type <n> RequiredTarget
 %type <n> SimpleName
 %type <n> StringData
+%type <n> StringLiteral
 %type <n> Target
 %type <n> Term
 %type <n> TermArg

--- a/src/acpica/source/compiler/aslwalks.c
+++ b/src/acpica/source/compiler/aslwalks.c
@@ -516,7 +516,7 @@ AnOperandTypecheckWalkEnd (
                     break;
                 }
 
-            /* Fallthrough */
+                ACPI_FALLTHROUGH;
 
             case ARGI_STORE_TARGET:
 

--- a/src/acpica/source/compiler/dtfield.c
+++ b/src/acpica/source/compiler/dtfield.c
@@ -227,7 +227,7 @@ DtCompileOneField (
             break;
         }
 
-        /* Fall through. */
+        ACPI_FALLTHROUGH;
 
     case DT_FIELD_TYPE_BUFFER:
 

--- a/src/acpica/source/compiler/dttemplate.c
+++ b/src/acpica/source/compiler/dttemplate.c
@@ -255,6 +255,7 @@ DtCreateTemplates (
 
     if (AcpiGbl_Optind < 3)
     {
+        fprintf (stderr, "Creating default template: [DSDT]\n");
         Status = DtCreateOneTemplateFile (ACPI_SIG_DSDT, 0);
         goto Exit;
     }
@@ -640,7 +641,7 @@ DtCreateOneTemplate (
     {
         fprintf (stderr,
             "Created ACPI table templates for [%4.4s] "
-            "and %u [SSDT], written to \"%s\"\n",
+            "and %u [SSDT] in same file, written to \"%s\"\n",
             Signature, TableCount, DisasmFilename);
     }
 

--- a/src/acpica/source/components/debugger/dbinput.c
+++ b/src/acpica/source/components/debugger/dbinput.c
@@ -642,7 +642,7 @@ AcpiDbGetNextToken (
 
     /* Remove any spaces at the beginning, ignore blank lines */
 
-    while (*String && isspace (*String))
+    while (*String && isspace ((int) *String))
     {
         String++;
     }
@@ -754,7 +754,7 @@ AcpiDbGetNextToken (
 
         /* Find end of token */
 
-        while (*String && !isspace (*String))
+        while (*String && !isspace ((int) *String))
         {
             String++;
         }

--- a/src/acpica/source/components/debugger/dbobject.c
+++ b/src/acpica/source/components/debugger/dbobject.c
@@ -201,7 +201,7 @@ AcpiDbDumpMethodInfo (
 
     /* Ignore control codes, they are not errors */
 
-    if ((Status & AE_CODE_MASK) == AE_CODE_CONTROL)
+    if (ACPI_CNTL_EXCEPTION (Status))
     {
         return;
     }

--- a/src/acpica/source/components/disassembler/dmwalk.c
+++ b/src/acpica/source/components/disassembler/dmwalk.c
@@ -400,7 +400,7 @@ AcpiDmBlockType (
             return (BLOCK_NONE);
         }
 
-        /*lint -fallthrough */
+        ACPI_FALLTHROUGH;
 
     case AML_PACKAGE_OP:
     case AML_VARIABLE_PACKAGE_OP:
@@ -422,7 +422,7 @@ AcpiDmBlockType (
             return (BLOCK_NONE);
         }
 
-        /*lint -fallthrough */
+        ACPI_FALLTHROUGH;
 
     default:
 
@@ -688,7 +688,7 @@ AcpiDmDescendingOp (
                 return (AE_OK);
             }
 
-            /* Fallthrough */
+            ACPI_FALLTHROUGH;
 
         default:
 
@@ -772,7 +772,7 @@ AcpiDmDescendingOp (
                 AcpiDmNamestring (NextOp->Common.Value.Name);
                 AcpiOsPrintf (", ");
 
-                /*lint -fallthrough */
+                ACPI_FALLTHROUGH;
 
             default:
 

--- a/src/acpica/source/components/dispatcher/dscontrol.c
+++ b/src/acpica/source/components/dispatcher/dscontrol.c
@@ -210,7 +210,7 @@ AcpiDsExecBeginControlOp (
             }
         }
 
-        /*lint -fallthrough */
+        ACPI_FALLTHROUGH;
 
     case AML_IF_OP:
         /*

--- a/src/acpica/source/components/dispatcher/dsdebug.c
+++ b/src/acpica/source/components/dispatcher/dsdebug.c
@@ -254,7 +254,7 @@ AcpiDsDumpMethodStack (
 
     /* Ignore control codes, they are not errors */
 
-    if ((Status & AE_CODE_MASK) == AE_CODE_CONTROL)
+    if (ACPI_CNTL_EXCEPTION (Status))
     {
         return_VOID;
     }

--- a/src/acpica/source/components/dispatcher/dswexec.c
+++ b/src/acpica/source/components/dispatcher/dswexec.c
@@ -772,8 +772,7 @@ AcpiDsExecEndOp (
                     break;
                 }
 
-                /* Fall through */
-                /*lint -fallthrough */
+                ACPI_FALLTHROUGH;
 
             case AML_INT_EVAL_SUBTREE_OP:
 

--- a/src/acpica/source/components/dispatcher/dswload.c
+++ b/src/acpica/source/components/dispatcher/dswload.c
@@ -375,7 +375,7 @@ AcpiDsLoad1BeginOp (
                 break;
             }
 
-            /*lint -fallthrough */
+            ACPI_FALLTHROUGH;
 
         default:
 

--- a/src/acpica/source/components/dispatcher/dswload2.c
+++ b/src/acpica/source/components/dispatcher/dswload2.c
@@ -366,7 +366,7 @@ AcpiDsLoad2BeginOp (
                 break;
             }
 
-            /*lint -fallthrough */
+            ACPI_FALLTHROUGH;
 
         default:
 

--- a/src/acpica/source/components/events/evregion.c
+++ b/src/acpica/source/components/events/evregion.c
@@ -164,8 +164,10 @@ extern UINT8        AcpiGbl_DefaultAddressSpaces[];
 /* Local prototypes */
 
 static void
-AcpiEvOrphanEcRegMethod (
-    ACPI_NAMESPACE_NODE     *EcDeviceNode);
+AcpiEvExecuteOrphanRegMethod (
+    ACPI_NAMESPACE_NODE     *DeviceNode,
+    ACPI_ADR_SPACE_TYPE     SpaceId);
+
 
 static ACPI_STATUS
 AcpiEvRegRun (
@@ -869,11 +871,13 @@ AcpiEvExecuteRegMethods (
     (void) AcpiNsWalkNamespace (ACPI_TYPE_ANY, Node, ACPI_UINT32_MAX,
         ACPI_NS_WALK_UNLOCK, AcpiEvRegRun, NULL, &Info, NULL);
 
-    /* Special case for EC: handle "orphan" _REG methods with no region */
-
-    if (SpaceId == ACPI_ADR_SPACE_EC)
+    /*
+     * Special case for EC and GPIO: handle "orphan" _REG methods with
+     * no region.
+     */
+    if (SpaceId == ACPI_ADR_SPACE_EC || SpaceId == ACPI_ADR_SPACE_GPIO)
     {
-        AcpiEvOrphanEcRegMethod (Node);
+        AcpiEvExecuteOrphanRegMethod (Node, SpaceId);
     }
 
     ACPI_DEBUG_PRINT_RAW ((ACPI_DB_NAMES,
@@ -954,32 +958,29 @@ AcpiEvRegRun (
 
 /*******************************************************************************
  *
- * FUNCTION:    AcpiEvOrphanEcRegMethod
+ * FUNCTION:    AcpiEvExecuteOrphanRegMethod
  *
- * PARAMETERS:  EcDeviceNode        - Namespace node for an EC device
+ * PARAMETERS:  DeviceNode          - Namespace node for an ACPI device
+ *              SpaceId             - The address space ID
  *
  * RETURN:      None
  *
- * DESCRIPTION: Execute an "orphan" _REG method that appears under the EC
+ * DESCRIPTION: Execute an "orphan" _REG method that appears under an ACPI
  *              device. This is a _REG method that has no corresponding region
- *              within the EC device scope. The orphan _REG method appears to
- *              have been enabled by the description of the ECDT in the ACPI
- *              specification: "The availability of the region space can be
- *              detected by providing a _REG method object underneath the
- *              Embedded Controller device."
- *
- *              To quickly access the EC device, we use the EcDeviceNode used
- *              during EC handler installation. Otherwise, we would need to
- *              perform a time consuming namespace walk, executing _HID
- *              methods to find the EC device.
+ *              within the device's scope. ACPI tables depending on these
+ *              "orphan" _REG methods have been seen for both EC and GPIO
+ *              Operation Regions. Presumably the Windows ACPI implementation
+ *              always calls the _REG method independent of the presence of
+ *              an actual Operation Region with the correct address space ID.
  *
  *  MUTEX:      Assumes the namespace is locked
  *
  ******************************************************************************/
 
 static void
-AcpiEvOrphanEcRegMethod (
-    ACPI_NAMESPACE_NODE     *EcDeviceNode)
+AcpiEvExecuteOrphanRegMethod (
+    ACPI_NAMESPACE_NODE     *DeviceNode,
+    ACPI_ADR_SPACE_TYPE     SpaceId)
 {
     ACPI_HANDLE             RegMethod;
     ACPI_NAMESPACE_NODE     *NextNode;
@@ -988,10 +989,10 @@ AcpiEvOrphanEcRegMethod (
     ACPI_OBJECT             Objects[2];
 
 
-    ACPI_FUNCTION_TRACE (EvOrphanEcRegMethod);
+    ACPI_FUNCTION_TRACE (EvExecuteOrphanRegMethod);
 
 
-    if (!EcDeviceNode)
+    if (!DeviceNode)
     {
         return_VOID;
     }
@@ -1002,7 +1003,7 @@ AcpiEvOrphanEcRegMethod (
 
     /* Get a handle to a _REG method immediately under the EC device */
 
-    Status = AcpiGetHandle (EcDeviceNode, METHOD_NAME__REG, &RegMethod);
+    Status = AcpiGetHandle (DeviceNode, METHOD_NAME__REG, &RegMethod);
     if (ACPI_FAILURE (Status))
     {
         goto Exit; /* There is no _REG method present */
@@ -1015,25 +1016,25 @@ AcpiEvOrphanEcRegMethod (
      * with other space IDs to be present; but the code below will then
      * execute the _REG method with the EmbeddedControl SpaceID argument.
      */
-    NextNode = AcpiNsGetNextNode (EcDeviceNode, NULL);
+    NextNode = AcpiNsGetNextNode (DeviceNode, NULL);
     while (NextNode)
     {
         if ((NextNode->Type == ACPI_TYPE_REGION) &&
             (NextNode->Object) &&
-            (NextNode->Object->Region.SpaceId == ACPI_ADR_SPACE_EC))
+            (NextNode->Object->Region.SpaceId == SpaceId))
         {
             goto Exit; /* Do not execute the _REG */
         }
 
-        NextNode = AcpiNsGetNextNode (EcDeviceNode, NextNode);
+        NextNode = AcpiNsGetNextNode (DeviceNode, NextNode);
     }
 
-    /* Evaluate the _REG(EmbeddedControl,Connect) method */
+    /* Evaluate the _REG(SpaceId,Connect) method */
 
     Args.Count = 2;
     Args.Pointer = Objects;
     Objects[0].Type = ACPI_TYPE_INTEGER;
-    Objects[0].Integer.Value = ACPI_ADR_SPACE_EC;
+    Objects[0].Integer.Value = SpaceId;
     Objects[1].Type = ACPI_TYPE_INTEGER;
     Objects[1].Integer.Value = ACPI_REG_CONNECT;
 

--- a/src/acpica/source/components/executer/exfldio.c
+++ b/src/acpica/source/components/executer/exfldio.c
@@ -616,7 +616,7 @@ AcpiExFieldDatumIo (
          * RegionField case and write the datum to the Operation Region
          */
 
-        /*lint -fallthrough */
+        ACPI_FALLTHROUGH;
 
     case ACPI_TYPE_LOCAL_REGION_FIELD:
         /*

--- a/src/acpica/source/components/executer/exresop.c
+++ b/src/acpica/source/components/executer/exresop.c
@@ -358,7 +358,7 @@ AcpiExResolveOperands (
 
                     TargetOp = AML_DEBUG_OP;
 
-                    /*lint -fallthrough */
+                    ACPI_FALLTHROUGH;
 
                 case ACPI_REFCLASS_ARG:
                 case ACPI_REFCLASS_LOCAL:
@@ -422,7 +422,7 @@ AcpiExResolveOperands (
              * Else not a string - fall through to the normal Reference
              * case below
              */
-            /*lint -fallthrough */
+            ACPI_FALLTHROUGH;
 
         case ARGI_REFERENCE:            /* References: */
         case ARGI_INTEGER_REF:

--- a/src/acpica/source/components/executer/exstore.c
+++ b/src/acpica/source/components/executer/exstore.c
@@ -248,7 +248,7 @@ AcpiExStore (
             return_ACPI_STATUS (AE_OK);
         }
 
-        /*lint -fallthrough */
+        ACPI_FALLTHROUGH;
 
     default:
 
@@ -585,7 +585,7 @@ AcpiExStoreObjectToNode (
                 break;
             }
 
-        /* Fallthrough */
+            ACPI_FALLTHROUGH;
 
         case ACPI_TYPE_DEVICE:
         case ACPI_TYPE_EVENT:

--- a/src/acpica/source/components/hardware/hwgpe.c
+++ b/src/acpica/source/components/hardware/hwgpe.c
@@ -254,7 +254,7 @@ AcpiHwLowSetGpe (
             return (AE_BAD_PARAMETER);
         }
 
-        /*lint -fallthrough */
+        ACPI_FALLTHROUGH;
 
     case ACPI_GPE_ENABLE:
 

--- a/src/acpica/source/components/namespace/nspredef.c
+++ b/src/acpica/source/components/namespace/nspredef.c
@@ -223,13 +223,14 @@ AcpiNsCheckReturnValue (
     ACPI_STATUS                 Status;
     const ACPI_PREDEFINED_INFO  *Predefined;
 
+    ACPI_FUNCTION_TRACE (NsCheckReturnValue);
 
     /* If not a predefined name, we cannot validate the return object */
 
     Predefined = Info->Predefined;
     if (!Predefined)
     {
-        return (AE_OK);
+        return_ACPI_STATUS (AE_OK);
     }
 
     /*
@@ -239,7 +240,7 @@ AcpiNsCheckReturnValue (
     if ((ReturnStatus != AE_OK) &&
         (ReturnStatus != AE_CTRL_RETURN_VALUE))
     {
-        return (AE_OK);
+        return_ACPI_STATUS (AE_OK);
     }
 
     /*
@@ -259,7 +260,7 @@ AcpiNsCheckReturnValue (
         (!Predefined->Info.ExpectedBtypes) ||
         (Predefined->Info.ExpectedBtypes == ACPI_RTYPE_ALL))
     {
-        return (AE_OK);
+        return_ACPI_STATUS (AE_OK);
     }
 
     /*
@@ -325,7 +326,7 @@ Exit:
         Node->Flags |= ANOBJ_EVALUATED;
     }
 
-    return (Status);
+    return_ACPI_STATUS (Status);
 }
 
 

--- a/src/acpica/source/components/namespace/nsprepkg.c
+++ b/src/acpica/source/components/namespace/nsprepkg.c
@@ -214,7 +214,7 @@ AcpiNsCheckPackage (
     UINT32                      i;
 
 
-    ACPI_FUNCTION_NAME (NsCheckPackage);
+    ACPI_FUNCTION_TRACE (NsCheckPackage);
 
 
     /* The package info for this name is in the next table entry */
@@ -245,13 +245,13 @@ AcpiNsCheckPackage (
     {
         if (Package->RetInfo.Type == ACPI_PTYPE1_VAR)
         {
-            return (AE_OK);
+            return_ACPI_STATUS (AE_OK);
         }
 
         ACPI_WARN_PREDEFINED ((AE_INFO, Info->FullPathname, Info->NodeFlags,
             "Return Package has no elements (empty)"));
 
-        return (AE_AML_OPERAND_VALUE);
+        return_ACPI_STATUS (AE_AML_OPERAND_VALUE);
     }
 
     /*
@@ -305,7 +305,7 @@ AcpiNsCheckPackage (
                 Package->RetInfo.ObjectType1, i);
             if (ACPI_FAILURE (Status))
             {
-                return (Status);
+                return_ACPI_STATUS (Status);
             }
 
             Elements++;
@@ -338,7 +338,7 @@ AcpiNsCheckPackage (
                     Package->RetInfo3.ObjectType[i], i);
                 if (ACPI_FAILURE (Status))
                 {
-                    return (Status);
+                    return_ACPI_STATUS (Status);
                 }
             }
             else
@@ -349,7 +349,7 @@ AcpiNsCheckPackage (
                     Package->RetInfo3.TailObjectType, i);
                 if (ACPI_FAILURE (Status))
                 {
-                    return (Status);
+                    return_ACPI_STATUS (Status);
                 }
             }
 
@@ -365,7 +365,7 @@ AcpiNsCheckPackage (
             Info, Elements, ACPI_RTYPE_INTEGER, 0);
         if (ACPI_FAILURE (Status))
         {
-            return (Status);
+            return_ACPI_STATUS (Status);
         }
 
         Elements++;
@@ -384,7 +384,7 @@ AcpiNsCheckPackage (
             Info, Elements, ACPI_RTYPE_INTEGER, 0);
         if (ACPI_FAILURE (Status))
         {
-            return (Status);
+            return_ACPI_STATUS (Status);
         }
 
         /*
@@ -428,7 +428,7 @@ AcpiNsCheckPackage (
                 Info, ReturnObject, ReturnObjectPtr);
             if (ACPI_FAILURE (Status))
             {
-                return (Status);
+                return_ACPI_STATUS (Status);
             }
 
             /* Update locals to point to the new package (of 1 element) */
@@ -466,7 +466,7 @@ AcpiNsCheckPackage (
                 Package->RetInfo.ObjectType1, 0);
             if (ACPI_FAILURE(Status))
             {
-                return (Status);
+                return_ACPI_STATUS (Status);
             }
 
             /* Validate length of the UUID buffer */
@@ -475,14 +475,14 @@ AcpiNsCheckPackage (
             {
                 ACPI_WARN_PREDEFINED ((AE_INFO, Info->FullPathname,
                     Info->NodeFlags, "Invalid length for UUID Buffer"));
-                return (AE_AML_OPERAND_VALUE);
+                return_ACPI_STATUS (AE_AML_OPERAND_VALUE);
             }
 
             Status = AcpiNsCheckObjectType(Info, Elements + 1,
                 Package->RetInfo.ObjectType2, 0);
             if (ACPI_FAILURE(Status))
             {
-                return (Status);
+                return_ACPI_STATUS (Status);
             }
 
             Elements += 2;
@@ -498,10 +498,10 @@ AcpiNsCheckPackage (
             "Invalid internal return type in table entry: %X",
             Package->RetInfo.Type));
 
-        return (AE_AML_INTERNAL);
+        return_ACPI_STATUS (AE_AML_INTERNAL);
     }
 
-    return (Status);
+    return_ACPI_STATUS (Status);
 
 
 PackageTooSmall:
@@ -512,7 +512,7 @@ PackageTooSmall:
         "Return Package is too small - found %u elements, expected %u",
         Count, ExpectedCount));
 
-    return (AE_AML_OPERAND_VALUE);
+    return_ACPI_STATUS (AE_AML_OPERAND_VALUE);
 }
 
 
@@ -865,6 +865,8 @@ AcpiNsCheckPackageElements (
     UINT32                      i;
 
 
+    ACPI_FUNCTION_TRACE (NsCheckPackageElements);
+
     /*
      * Up to two groups of package elements are supported by the data
      * structure. All elements in each group must be of the same type.
@@ -876,7 +878,7 @@ AcpiNsCheckPackageElements (
             Type1, i + StartIndex);
         if (ACPI_FAILURE (Status))
         {
-            return (Status);
+            return_ACPI_STATUS (Status);
         }
 
         ThisElement++;
@@ -888,11 +890,11 @@ AcpiNsCheckPackageElements (
             Type2, (i + Count1 + StartIndex));
         if (ACPI_FAILURE (Status))
         {
-            return (Status);
+            return_ACPI_STATUS (Status);
         }
 
         ThisElement++;
     }
 
-    return (AE_OK);
+    return_ACPI_STATUS (AE_OK);
 }

--- a/src/acpica/source/components/namespace/nsrepair2.c
+++ b/src/acpica/source/components/namespace/nsrepair2.c
@@ -321,16 +321,18 @@ AcpiNsComplexRepairs (
     ACPI_STATUS             Status;
 
 
+    ACPI_FUNCTION_TRACE (NsComplexRepairs);
+
     /* Check if this name is in the list of repairable names */
 
     Predefined = AcpiNsMatchComplexRepair (Node);
     if (!Predefined)
     {
-        return (ValidateStatus);
+        return_ACPI_STATUS (ValidateStatus);
     }
 
     Status = Predefined->RepairFunction (Info, ReturnObjectPtr);
-    return (Status);
+    return_ACPI_STATUS (Status);
 }
 
 
@@ -526,20 +528,21 @@ AcpiNsRepair_CID (
     UINT16                  OriginalRefCount;
     UINT32                  i;
 
+    ACPI_FUNCTION_TRACE (NsRepair_CID);
 
     /* Check for _CID as a simple string */
 
     if (ReturnObject->Common.Type == ACPI_TYPE_STRING)
     {
         Status = AcpiNsRepair_HID (Info, ReturnObjectPtr);
-        return (Status);
+        return_ACPI_STATUS (Status);
     }
 
     /* Exit if not a Package */
 
     if (ReturnObject->Common.Type != ACPI_TYPE_PACKAGE)
     {
-        return (AE_OK);
+        return_ACPI_STATUS (AE_OK);
     }
 
     /* Examine each element of the _CID package */
@@ -553,7 +556,7 @@ AcpiNsRepair_CID (
         Status = AcpiNsRepair_HID (Info, ElementPtr);
         if (ACPI_FAILURE (Status))
         {
-            return (Status);
+            return_ACPI_STATUS (Status);
         }
 
         if (OriginalElement != *ElementPtr)
@@ -567,7 +570,7 @@ AcpiNsRepair_CID (
         ElementPtr++;
     }
 
-    return (AE_OK);
+    return_ACPI_STATUS (AE_OK);
 }
 
 
@@ -687,9 +690,8 @@ AcpiNsRepair_HID (
     ACPI_OPERAND_OBJECT     **ReturnObjectPtr)
 {
     ACPI_OPERAND_OBJECT     *ReturnObject = *ReturnObjectPtr;
-    ACPI_OPERAND_OBJECT     *NewString;
-    char                    *Source;
     char                    *Dest;
+    char                    *Source;
 
 
     ACPI_FUNCTION_NAME (NsRepair_HID);
@@ -699,7 +701,7 @@ AcpiNsRepair_HID (
 
     if (ReturnObject->Common.Type != ACPI_TYPE_STRING)
     {
-        return (AE_OK);
+        return_ACPI_STATUS (AE_OK);
     }
 
     if (ReturnObject->String.Length == 0)
@@ -711,15 +713,7 @@ AcpiNsRepair_HID (
         /* Return AE_OK anyway, let driver handle it */
 
         Info->ReturnFlags |= ACPI_OBJECT_REPAIRED;
-        return (AE_OK);
-    }
-
-    /* It is simplest to always create a new string object */
-
-    NewString = AcpiUtCreateStringObject (ReturnObject->String.Length);
-    if (!NewString)
-    {
-        return (AE_NO_MEMORY);
+        return_ACPI_STATUS (AE_OK);
     }
 
     /*
@@ -732,7 +726,7 @@ AcpiNsRepair_HID (
     if (*Source == '*')
     {
         Source++;
-        NewString->String.Length--;
+        ReturnObject->String.Length--;
 
         ACPI_DEBUG_PRINT ((ACPI_DB_REPAIR,
             "%s: Removed invalid leading asterisk\n", Info->FullPathname));
@@ -746,14 +740,13 @@ AcpiNsRepair_HID (
      * "NNNN####" where N is an uppercase letter or decimal digit, and
      * # is a hex digit.
      */
-    for (Dest = NewString->String.Pointer; *Source; Dest++, Source++)
+    for (Dest = ReturnObject->String.Pointer; *Source; Dest++, Source++)
     {
         *Dest = (char) toupper ((int) *Source);
     }
+    ReturnObject->String.Pointer[ReturnObject->String.Length] = 0;
 
-    AcpiUtRemoveReference (ReturnObject);
-    *ReturnObjectPtr = NewString;
-    return (AE_OK);
+    return_ACPI_STATUS (AE_OK);
 }
 
 

--- a/src/acpica/source/components/parser/psloop.c
+++ b/src/acpica/source/components/parser/psloop.c
@@ -410,8 +410,7 @@ AcpiPsParseLoop (
                  */
                 WalkState->Op = NULL;
                 Status = AcpiDsGetPredicateValue (WalkState, ACPI_TO_POINTER (TRUE));
-                if (ACPI_FAILURE (Status) &&
-                    ((Status & AE_CODE_MASK) != AE_CODE_CONTROL))
+                if (ACPI_FAILURE (Status) && !ACPI_CNTL_EXCEPTION (Status))
                 {
                     if (Status == AE_AML_NO_RETURN_VALUE)
                     {

--- a/src/acpica/source/components/parser/psparse.c
+++ b/src/acpica/source/components/parser/psparse.c
@@ -533,7 +533,7 @@ AcpiPsNextParseState (
     default:
 
         Status = CallbackStatus;
-        if ((CallbackStatus & AE_CODE_MASK) == AE_CODE_CONTROL)
+        if (ACPI_CNTL_EXCEPTION (CallbackStatus))
         {
             Status = AE_OK;
         }

--- a/src/acpica/source/components/utilities/utdelete.c
+++ b/src/acpica/source/components/utilities/utdelete.c
@@ -266,7 +266,7 @@ AcpiUtDeleteInternalObj (
             (void) AcpiEvDeleteGpeBlock (Object->Device.GpeBlock);
         }
 
-        /*lint -fallthrough */
+        ACPI_FALLTHROUGH;
 
     case ACPI_TYPE_PROCESSOR:
     case ACPI_TYPE_THERMAL:

--- a/src/acpica/source/components/utilities/utstrsuppt.c
+++ b/src/acpica/source/components/utilities/utstrsuppt.c
@@ -274,7 +274,7 @@ AcpiUtConvertDecimalString (
          * 1) Runtime: terminate with no error, per the ACPI spec
          * 2) Compiler: return an error
          */
-        if (!isdigit (*String))
+        if (!isdigit ((int) *String))
         {
 #ifdef ACPI_ASL_COMPILER
             Status = AE_BAD_DECIMAL_CONSTANT;
@@ -336,7 +336,7 @@ AcpiUtConvertHexString (
          * 1) Runtime: terminate with no error, per the ACPI spec
          * 2) Compiler: return an error
          */
-        if (!isxdigit (*String))
+        if (!isxdigit ((int) *String))
         {
 #ifdef ACPI_ASL_COMPILER
             Status = AE_BAD_HEX_CONSTANT;

--- a/src/acpica/source/include/accommon.h
+++ b/src/acpica/source/include/accommon.h
@@ -155,7 +155,7 @@
 /*
  * Common set of includes for all ACPICA source files.
  * We put them here because we don't want to duplicate them
- * in the the source code again and again.
+ * in the source code again and again.
  *
  * Note: The order of these include files is important.
  */

--- a/src/acpica/source/include/acexcep.h
+++ b/src/acpica/source/include/acexcep.h
@@ -204,11 +204,11 @@ typedef struct acpi_exception_info
 
 #define AE_OK                           (ACPI_STATUS) 0x0000
 
-#define ACPI_ENV_EXCEPTION(Status)      (Status & AE_CODE_ENVIRONMENTAL)
-#define ACPI_AML_EXCEPTION(Status)      (Status & AE_CODE_AML)
-#define ACPI_PROG_EXCEPTION(Status)     (Status & AE_CODE_PROGRAMMER)
-#define ACPI_TABLE_EXCEPTION(Status)    (Status & AE_CODE_ACPI_TABLES)
-#define ACPI_CNTL_EXCEPTION(Status)     (Status & AE_CODE_CONTROL)
+#define ACPI_ENV_EXCEPTION(Status)      (((Status) & AE_CODE_MASK) == AE_CODE_ENVIRONMENTAL)
+#define ACPI_AML_EXCEPTION(Status)      (((Status) & AE_CODE_MASK) == AE_CODE_AML)
+#define ACPI_PROG_EXCEPTION(Status)     (((Status) & AE_CODE_MASK) == AE_CODE_PROGRAMMER)
+#define ACPI_TABLE_EXCEPTION(Status)    (((Status) & AE_CODE_MASK) == AE_CODE_ACPI_TABLES)
+#define ACPI_CNTL_EXCEPTION(Status)     (((Status) & AE_CODE_MASK) == AE_CODE_CONTROL)
 
 
 /*

--- a/src/acpica/source/include/acpixf.h
+++ b/src/acpica/source/include/acpixf.h
@@ -154,7 +154,7 @@
 
 /* Current ACPICA subsystem version in YYYYMMDD format */
 
-#define ACPI_CA_VERSION                 0x20200925
+#define ACPI_CA_VERSION                 0x20201113
 
 #include "acconfig.h"
 #include "actypes.h"

--- a/src/acpica/source/include/acpixf.h
+++ b/src/acpica/source/include/acpixf.h
@@ -154,7 +154,7 @@
 
 /* Current ACPICA subsystem version in YYYYMMDD format */
 
-#define ACPI_CA_VERSION                 0x20201113
+#define ACPI_CA_VERSION                 0x20201217
 
 #include "acconfig.h"
 #include "actypes.h"

--- a/src/acpica/source/include/actypes.h
+++ b/src/acpica/source/include/actypes.h
@@ -1537,5 +1537,10 @@ typedef enum
 
 #define ACPI_OPT_END                    -1
 
+/* Definitions for explicit fallthrough */
+
+#ifndef ACPI_FALLTHROUGH
+#define ACPI_FALLTHROUGH do {} while(0)
+#endif
 
 #endif /* __ACTYPES_H__ */

--- a/src/acpica/source/include/acuuid.h
+++ b/src/acpica/source/include/acuuid.h
@@ -181,6 +181,7 @@
 
 /* NVDIMM - NFIT table */
 
+#define UUID_NFIT_DIMM                  "4309ac30-0d11-11e4-9191-0800200c9a66"
 #define UUID_VOLATILE_MEMORY            "7305944f-fdda-44e3-b16c-3f22d252e5d0"
 #define UUID_PERSISTENT_MEMORY          "66f0d379-b4f3-4074-ac43-0d3318b78cdb"
 #define UUID_CONTROL_REGION             "92f701f6-13b4-405d-910b-299367e8234c"
@@ -189,6 +190,10 @@
 #define UUID_VOLATILE_VIRTUAL_CD        "3d5abd30-4175-87ce-6d64-d2ade523c4bb"
 #define UUID_PERSISTENT_VIRTUAL_DISK    "5cea02c9-4d07-69d3-269f-4496fbe096f9"
 #define UUID_PERSISTENT_VIRTUAL_CD      "08018188-42cd-bb48-100f-5387d53ded3d"
+#define UUID_NFIT_DIMM_N_MSFT           "1ee68b36-d4bd-4a1a-9a16-4f8e53d46e05"
+#define UUID_NFIT_DIMM_N_HPE1           "9002c334-acf3-4c0e-9642-a235f0d53bc6"
+#define UUID_NFIT_DIMM_N_HPE2           "5008664b-b758-41a0-a03c-27c2f2d04f7e"
+#define UUID_NFIT_DIMM_N_HYPERV         "5746c5f2-a9a2-4264-ad0e-e4ddc9e09e80"
 
 /* Processor Properties (ACPI 6.2) */
 

--- a/src/acpica/source/include/platform/acgcc.h
+++ b/src/acpica/source/include/platform/acgcc.h
@@ -196,4 +196,19 @@ typedef __builtin_va_list       va_list;
 
 #define ACPI_USE_NATIVE_MATH64
 
+/* GCC did not support __has_attribute until 5.1. */
+
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
+/*
+ * Explictly mark intentional explicit fallthrough to silence
+ * -Wimplicit-fallthrough in GCC 7.1+.
+ */
+
+#if __has_attribute(__fallthrough__)
+#define ACPI_FALLTHROUGH __attribute__((__fallthrough__))
+#endif
+
 #endif /* __ACGCC_H__ */

--- a/src/bios/bios_info/bios_info.c
+++ b/src/bios/bios_info/bios_info.c
@@ -57,7 +57,7 @@ static int bios_info_test1(fwts_framework *fw)
 
 	for (i = 0; bios_info[i].dmi_field != NULL; i++) {
 		char *data;
-		snprintf(path, sizeof(path), "/sys/class/dmi/id/%s", 
+		snprintf(path, sizeof(path), "/sys/class/dmi/id/%s",
 			bios_info[i].dmi_field);
 		if ((data = fwts_get(path)) != NULL) {
 			fwts_chop_newline(data);

--- a/src/bios/ebda_region/ebda_region.c
+++ b/src/bios/ebda_region/ebda_region.c
@@ -95,7 +95,7 @@ static int ebda_test1(fwts_framework *fw)
 			"EBDAMappedNotReserved",
 			"EBDA region mapped at 0x%lx but not reserved in the %s table.",
 			ebda_addr, memory_map_name);
-		
+
 	return FWTS_OK;
 }
 

--- a/src/cpu/maxfreq/maxfreq.c
+++ b/src/cpu/maxfreq/maxfreq.c
@@ -18,8 +18,6 @@
  */
 #include "fwts.h"
 
-#ifdef FWTS_ARCH_INTEL
-
 #include <stdlib.h>
 #include <stdbool.h>
 #include <sys/types.h>
@@ -79,9 +77,11 @@ static int maxfreq_test1(fwts_framework *fw)
 			cpus++;
 	}
 	if (!cpus) {
-		fwts_log_error(fw, "Cannot find any CPUs.");
 		fwts_list_free(cpuinfo, free);
-		return FWTS_ERROR;
+		fwts_skipped(fw,
+			"Cannot read CPU model names from %s, this generally "
+			"happens on ARM CPUs, skipping test.", CPU_INFO_PATH);
+		return FWTS_SKIP;
 	}
 
 	if ((cpufreq = calloc(cpus, sizeof(double))) == NULL) {
@@ -215,4 +215,3 @@ static fwts_framework_ops maxfreq_ops = {
 
 FWTS_REGISTER("maxfreq", &maxfreq_ops, FWTS_TEST_ANYTIME, FWTS_FLAG_BATCH)
 
-#endif

--- a/src/cpu/msr/msr.c
+++ b/src/cpu/msr/msr.c
@@ -270,7 +270,9 @@ static const msr_info AMD_MSRs[] = {
 	{ "MCG_CAP",			0x00000179,	0x0000000001ff0fffULL, NULL },
 	  */
 	{ "MCG_STATUS",			0x0000017a,	0xffffffffffffffffULL, NULL },
+	/* MCG_CTL differs in Ryzen 4000 series and probably later series
 	{ "MCG_CTL",			0x0000017b,	0xffffffffffffffffULL, NULL },
+	*/
 	{ "MTRR_PHYSBASE0",		0x00000200,	0xffffffffffffffffULL, NULL },
 	{ "MTRR_PHYSMASK0",		0x00000201,	0xffffffffffffffffULL, NULL },
 	{ "MTRR_PHYSBASE1",		0x00000202,	0xffffffffffffffffULL, NULL },

--- a/src/devicetree/dt_sysinfo/dt_sysinfo.c
+++ b/src/devicetree/dt_sysinfo/dt_sysinfo.c
@@ -46,9 +46,9 @@ static struct reference_platform {
 	int		n_models;
 } openpower_reference_platforms[] = {
 	{"ibm,firestone", firestone_models,
-		FWTS_ARRAY_LEN(firestone_models)},
+		FWTS_ARRAY_SIZE(firestone_models)},
 	{"ibm,garrison", garrison_models,
-		FWTS_ARRAY_LEN(garrison_models)},
+		FWTS_ARRAY_SIZE(garrison_models)},
 };
 
 
@@ -224,7 +224,7 @@ static bool machine_matches_reference_model(fwts_framework *fw,
 	struct reference_platform *plat;
 	int i;
 
-	for (i = 0; i < (int)FWTS_ARRAY_LEN(openpower_reference_platforms);
+	for (i = 0; i < (int)FWTS_ARRAY_SIZE(openpower_reference_platforms);
 			i++) {
 		plat = &openpower_reference_platforms[i];
 		if (dt_fdt_stringlist_contains_last(compatible,

--- a/src/dmi/dmicheck/dmicheck.c
+++ b/src/dmi/dmicheck/dmicheck.c
@@ -35,7 +35,7 @@
 #include <limits.h>
 #include <fcntl.h>
 
-#define DMI_VERSION			(0x0330)
+#define DMI_VERSION			(0x0340)
 #define VERSION_MAJOR(v)		((v) >> 8)
 #define VERSION_MINOR(v)		((v) & 0xff)
 
@@ -1357,7 +1357,7 @@ static void dmicheck_entry(fwts_framework *fw,
 			dmi_min_max_uint8_check(fw, table, addr, "Processor Type", hdr, 0x5, 0x1, 0x6);
 			dmi_str_check(fw, table, addr, "Processor Manufacturer", hdr, 0x7);
 			dmi_str_check(fw, table, addr, "Processor Version", hdr, 0x10);
-			dmi_min_max_uint8_check(fw, table, addr, "Upgrade", hdr, 0x19, 0x1, 0x3c);
+			dmi_min_max_uint8_check(fw, table, addr, "Upgrade", hdr, 0x19, 0x1, 0x3e);
 			if (hdr->length < 0x23)
 				break;
 			dmi_str_check(fw, table, addr, "Serial Number", hdr, 0x20);
@@ -1431,7 +1431,7 @@ static void dmicheck_entry(fwts_framework *fw,
 			if (hdr->length < 0x0c)
 				break;
 			dmi_str_check(fw, table, addr, "Slot Designation", hdr, 0x4);
-			fwts_dmi_value_range t9_ranges[] = {{1, 0x23}, {0x30, 0x30}, {0xa0, 0xbd}};
+			fwts_dmi_value_range t9_ranges[] = {{1, 0x28}, {0x30, 0x30}, {0xa0, 0xc6}};
 			dmi_ranges_uint8_check(fw, table, addr, "Slot Type", hdr, 0x5, t9_ranges, sizeof(t9_ranges));
 			dmi_min_max_uint8_check(fw, table, addr, "Slot Data Bus Width", hdr, 0x6, 0x1, 0xe);
 			dmi_min_max_uint8_check(fw, table, addr, "Current Usage", hdr, 0x7, 0x1, 0x5);
@@ -1439,13 +1439,13 @@ static void dmicheck_entry(fwts_framework *fw,
 			if (hdr->length < 0x0d)
 				break;
 
-			dmi_reserved_bits_check(fw, table, addr, "Slot Characteristics 2", hdr, sizeof(uint8_t), 0x0c, 4, 7);
+			dmi_reserved_bits_check(fw, table, addr, "Slot Characteristics 2", hdr, sizeof(uint8_t), 0x0c, 7, 7);
 
 			if (hdr->length < 0x11)
 				break;
 			if (!((data[0x5] == 0x06) ||
-			      ((data[0x5] >= 0x0e) && (data[0x5] <= 0x23)) ||
-			      ((data[0x5] >= 0xa0) && (data[0x5] <= 0xb6)))) {
+			      ((data[0x5] >= 0x0e) && (data[0x5] <= 0x28)) ||
+			      ((data[0x5] >= 0xa0) && (data[0x5] <= 0xc6)))) {
 				if (GET_UINT16(data + 0xd) != 0xffff)
 					fwts_failed(fw, LOG_LEVEL_MEDIUM, DMI_VALUE_OUT_OF_RANGE,
 						"Invalid value 0x%4.4" PRIx16 " was used and 0xffff "
@@ -1594,7 +1594,7 @@ static void dmicheck_entry(fwts_framework *fw,
 			dmi_min_max_uint8_check(fw, table, addr, "Form Factor", hdr, 0xe, 0x1, 0x10);
 			dmi_str_check(fw, table, addr, "Locator", hdr, 0x10);
 			dmi_str_check(fw, table, addr, "Bank Locator", hdr, 0x11);
-			dmi_min_max_uint8_check(fw, table, addr, "Memory Type", hdr, 0x12, 0x1, 0x21);
+			dmi_min_max_uint8_check(fw, table, addr, "Memory Type", hdr, 0x12, 0x1, 0x23);
 			if (hdr->length < 0x1b)
 				break;
 			dmi_str_check(fw, table, addr, "Manufacturer", hdr, 0x17);

--- a/src/dmi/dmicheck/dmicheck.c
+++ b/src/dmi/dmicheck/dmicheck.c
@@ -2230,6 +2230,9 @@ static int dmicheck_test3(fwts_framework *fw)
 		return FWTS_ERROR;
 	}
 
+	if (dmi_version_check(fw, version) != FWTS_OK)
+		return FWTS_SKIP;
+
 	table = dmi_table_smbios30(fw, &entry30);
 	if (table == NULL)
 		return FWTS_ERROR;

--- a/src/example/blank/blank.c
+++ b/src/example/blank/blank.c
@@ -44,7 +44,7 @@ static int example_deinit(fwts_framework *fw)
 static int example_test1(fwts_framework *fw)
 {
 	/* Do your test */
-	
+
 	/* Log success or failure */
 	fwts_passed(fw, "Test passed, hurrah!");
 	/*
@@ -61,7 +61,7 @@ static int example_test1(fwts_framework *fw)
 static int example_test2(fwts_framework *fw)
 {
 	/* Do your test */
-	
+
 	/* Log success or failure */
 	fwts_passed(fw, "Test passed, hurrah!");
 	/*

--- a/src/kernel/klog/klog.c
+++ b/src/kernel/klog/klog.c
@@ -63,7 +63,7 @@ static int klog_test1(fwts_framework *fw)
 		return FWTS_ERROR;
 	}
 
-	if (errors > 0) 
+	if (errors > 0)
 		/* Checks will log errors as failures automatically */
 		fwts_log_info(fw, "Found %d unique errors in kernel log.",
 			errors);

--- a/src/lib/include/fwts.h
+++ b/src/lib/include/fwts.h
@@ -105,6 +105,7 @@
 #define FWTS_ARCH_AARCH64	1
 #define FWTS_HAS_ACPI	1
 #define FWTS_HAS_UEFI	1
+#define FWTS_USE_DEVMEM 1
 #endif
 
 #if defined(__s390x__)

--- a/src/lib/include/fwts_acpi.h
+++ b/src/lib/include/fwts_acpi.h
@@ -105,10 +105,8 @@
 #include "fwts_framework.h"
 #include "fwts_log.h"
 
-extern const char *fwts_acpi_fadt_preferred_pm_profile[];
+const char *fwts_acpi_fadt_preferred_pm_profile(const int profile);
 
-#define FWTS_ACPI_FADT_PREFERRED_PM_PROFILE(x)		\
-	((x) > 8) ? "Reserved" : fwts_acpi_fadt_preferred_pm_profile[x]
 #define FWTS_ACPI_FADT_FLAGS_HW_REDUCED_ACPI (1<<20)
 
 /*

--- a/src/lib/include/fwts_acpi.h
+++ b/src/lib/include/fwts_acpi.h
@@ -115,9 +115,9 @@ const char *fwts_acpi_fadt_preferred_pm_profile(const int profile);
 typedef struct {
 	uint8_t 	address_space_id;
 	uint8_t		register_bit_width;
-        uint8_t 	register_bit_offset;
-        uint8_t 	access_width;
-        uint64_t 	address;
+	uint8_t 	register_bit_offset;
+	uint8_t 	access_width;
+	uint64_t 	address;
 } __attribute__ ((packed)) fwts_acpi_gas;
 
 /*
@@ -1828,6 +1828,7 @@ typedef struct {
 } __attribute__ ((packed)) fwts_acpi_table_hest_generic_hardware_error_source_v2;
 
 void fwts_acpi_table_get_header(fwts_acpi_table_header *hdr, uint8_t *data);
+bool fwts_acpi_data_zero(const void *data, const size_t len);
 
 /*
  * ACPI CSTR (Core System Resources Table)

--- a/src/lib/include/fwts_acpi_object_eval.h
+++ b/src/lib/include/fwts_acpi_object_eval.h
@@ -119,7 +119,8 @@ int fwts_method_buffer_size(fwts_framework *fw, const char *name, ACPI_OBJECT *o
 int fwts_method_package_count_min(fwts_framework *fw, const char *name, const char *objname, const ACPI_OBJECT *obj, const uint32_t min);
 int fwts_method_package_count_equal(fwts_framework *fw, const char *name, const char *objname, const ACPI_OBJECT *obj, const uint32_t count);
 int fwts_method_package_elements_all_type(fwts_framework *fw, const char *name, const char *objname, const ACPI_OBJECT *obj, const ACPI_OBJECT_TYPE type);
-int fwts_method_package_elements_type( fwts_framework *fw, const char *name, const char *objname, const ACPI_OBJECT *obj, const fwts_package_element *info, const uint32_t count);
+int fwts_method_package_elements_type(fwts_framework *fw, const char *name, const char *objname, const ACPI_OBJECT *obj, const fwts_package_element *info, const uint32_t count);
+int fwts_method_test_revision(fwts_framework *fw, const char *name, const uint32_t cur_revision, const uint32_t spec_revision);
 
 void fwts_method_test_integer_return(fwts_framework *fw, char *name, ACPI_BUFFER *buf, ACPI_OBJECT *obj, void *private);
 void fwts_method_test_string_return(fwts_framework *fw, char *name, ACPI_BUFFER *buf, ACPI_OBJECT *obj, void *private);

--- a/src/lib/include/fwts_acpi_tables.h
+++ b/src/lib/include/fwts_acpi_tables.h
@@ -43,6 +43,14 @@ typedef struct {
 	fwts_acpi_table_provenance provenance;
 } fwts_acpi_table_info;
 
+int acpi_table_generic_init(fwts_framework *fw, char *name, fwts_acpi_table_info **table);
+
+#define acpi_table_init(name, table)				\
+static int name ## _init (fwts_framework *fw)			\
+{								\
+	return acpi_table_generic_init(fw, # name, table);	\
+}
+
 int fwts_acpi_load_tables(fwts_framework *fw);
 int fwts_acpi_free_tables(void);
 

--- a/src/lib/include/fwts_acpi_tables.h
+++ b/src/lib/include/fwts_acpi_tables.h
@@ -51,7 +51,7 @@ int fwts_acpi_find_table_by_addr(fwts_framework *fw, const uint64_t addr, fwts_a
 int fwts_acpi_get_table(fwts_framework *fw, const uint32_t index, fwts_acpi_table_info **info);
 bool fwts_acpi_obj_find(fwts_framework *fw, const char *obj_name);
 
-fwts_bool fwts_acpi_is_reduced_hardware(const fwts_acpi_table_fadt *fadt);
+fwts_bool fwts_acpi_is_reduced_hardware(fwts_framework *fw);
 
 void fwts_acpi_reserved_zero_check(fwts_framework *fw, const char *table, const char *field, uint64_t value, uint8_t size, bool *passed);
 void fwts_acpi_reserved_zero_array_check(fwts_framework *fw, const char *table, const char *field, uint8_t* data, uint8_t length, bool *passed);

--- a/src/lib/include/fwts_efi_runtime.h
+++ b/src/lib/include/fwts_efi_runtime.h
@@ -158,4 +158,10 @@ struct efi_querycapsulecapabilities {
 #define EFI_RUNTIME_QUERY_CAPSULECAPABILITIES \
 	_IOR('p', 0x0A, struct efi_querycapsulecapabilities)
 
+#define EFI_RUNTIME_RESET_SYSTEM \
+	_IOW('p', 0x0B, struct efi_resetsystem)
+
+#define EFI_RUNTIME_GET_SUPPORTED_MASK \
+	_IOR('p', 0x0C, unsigned int)
+
 #endif /* _FWTS_EFI_RUNTIME_H_ */

--- a/src/lib/include/fwts_framework.h
+++ b/src/lib/include/fwts_framework.h
@@ -27,6 +27,7 @@
 
 typedef struct fwts_framework fwts_framework;
 
+#include "fwts.h"
 #include "fwts_arch.h"
 #include "fwts_log.h"
 #include "fwts_list.h"
@@ -259,8 +260,6 @@ static inline int fwts_tests_passed(const fwts_framework *fw)
 	(flags & (FWTS_FLAG_INTERACTIVE | \
 		  FWTS_FLAG_INTERACTIVE_EXPERIMENTAL))
 
-#define FWTS_ARRAY_LEN(s) (sizeof(s)/sizeof(s[0]))
-
 /*
  * FWTS_ASSERT(test, message)
  *	compile time assertion that throws a division by zero
@@ -275,8 +274,7 @@ enum { FWTS_CONCAT_EXPAND(FWTS_ASSERT_ ## m ## _in_line_, __LINE__) = 1 / !!(e) 
 
 #define FWTS_REGISTER_FEATURES(name, ops, priority, flags, features)	\
 /* Ensure name is not too long */					\
-FWTS_ASSERT(FWTS_ARRAY_LEN(name) < 16,					\
-	fwts_register_name_too_long);					\
+FWTS_ASSERT(FWTS_ARRAY_SIZE(name) < 16,	fwts_register_name_too_long);	\
 									\
 static void __test_init (void) __attribute__ ((constructor));		\
 									\

--- a/src/lib/include/fwts_pci.h
+++ b/src/lib/include/fwts_pci.h
@@ -151,6 +151,8 @@
 #define FWTS_PCI_SUBCLASS_CODE_OTHER_SYSTEM_PERIPHERAL	(0x80)
 #define FWTS_PCI_SUBCLASS_CODE_AUDIO_DEVICE		(0x03)
 
+/* PCI Vendor IDs */
+#define FWTS_PCI_INTEL_VENDOR_ID			(0x8086)
 
 /*
  * PCI Express Capability Structure is defined in Section 7.8

--- a/src/lib/include/fwts_tpm.h
+++ b/src/lib/include/fwts_tpm.h
@@ -167,6 +167,9 @@ typedef struct {
 */
 } __attribute__ ((packed)) fwts_tcg_pcr_event2;
 
+void fwts_tpm_data_hexdump(fwts_framework *fw, uint8_t *data, size_t size, char *str);
+uint8_t fwts_tpm_get_hash_size(TPM2_ALG_ID hash);
+
 PRAGMA_POP
 
 #endif

--- a/src/lib/include/fwts_uefi.h
+++ b/src/lib/include/fwts_uefi.h
@@ -137,6 +137,8 @@ enum {
 #define EFI_RT_SUPPORTED_QUERY_CAPSULE_CAPABILITIES	0x1000
 #define EFI_RT_SUPPORTED_QUERY_VARIABLE_INFO		0x2000
 
+#define EFI_RT_SUPPORTED_ALL				0x3fff
+
 #define EFI_CERT_SHA256_GUID \
 { 0xc1c41626, 0x504c, 0x4092, { 0xac, 0xa9, 0x41, 0xf9, 0x36, 0x93, 0x43, 0x28 }}
 
@@ -680,7 +682,7 @@ char *fwts_uefi_attribute_info(uint32_t attr);
 
 bool fwts_uefi_efivars_iface_exist(void);
 
-void fwts_uefi_rt_support_status_get(int fd, bool *getvar_supported, uint32_t *var_rtsupported);
+void fwts_uefi_rt_support_status_get(int fd, uint32_t *var_rtsupported);
 
 PRAGMA_POP
 

--- a/src/lib/include/fwts_version.h
+++ b/src/lib/include/fwts_version.h
@@ -16,5 +16,5 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#define FWTS_VERSION "V20.09.00"
-#define FWTS_DATE    "2020-09-17 18:08:13"
+#define FWTS_VERSION "V20.11.00"
+#define FWTS_DATE    "2020-11-25 09:22:52"

--- a/src/lib/include/fwts_version.h
+++ b/src/lib/include/fwts_version.h
@@ -16,5 +16,5 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#define FWTS_VERSION "V20.11.00"
-#define FWTS_DATE    "2020-11-25 09:22:52"
+#define FWTS_VERSION "V20.12.00"
+#define FWTS_DATE    "2020-12-17 02:15:43"

--- a/src/lib/src/Makefile.am
+++ b/src/lib/src/Makefile.am
@@ -107,6 +107,7 @@ libfwts_la_SOURCES = 		\
 	fwts_stringextras.c 	\
 	fwts_summary.c 		\
 	fwts_text_list.c 	\
+	fwts_tpm.c		\
 	fwts_tty.c 		\
 	fwts_uefi.c 		\
 	fwts_wakealarm.c 	\

--- a/src/lib/src/fwts_acpi.c
+++ b/src/lib/src/fwts_acpi.c
@@ -30,17 +30,25 @@
 
 #if defined(FWTS_HAS_ACPI)
 
-const char *fwts_acpi_fadt_preferred_pm_profile[] = {
-	"Unspecified",
-	"Desktop",
-	"Mobile",
-	"Workstation",
-	"Enterprise Server",
-	"SOHO Server",
-	"Appliance PC",
-	"Performance Server",
-	"Tablet",
-};
+const char *fwts_acpi_fadt_preferred_pm_profile(const int profile)
+{
+	static const char *pm_profiles[] = {
+		"Unspecified",
+		"Desktop",
+		"Mobile",
+		"Workstation",
+		"Enterprise Server",
+		"SOHO Server",
+		"Appliance PC",
+		"Performance Server",
+		"Tablet"
+	};
+
+	if ((profile < 0) || profile >= (int)(FWTS_ARRAY_SIZE(pm_profiles)))
+		return "Reserved";
+
+	return pm_profiles[profile];
+}
 
 /*
  *  fwts_acpi_table_get_header()

--- a/src/lib/src/fwts_acpi.c
+++ b/src/lib/src/fwts_acpi.c
@@ -59,4 +59,15 @@ void fwts_acpi_table_get_header(fwts_acpi_table_header *hdr, uint8_t *data)
 	memcpy(hdr, data, sizeof(fwts_acpi_table_header));
 }
 
+bool fwts_acpi_data_zero(const void *data, const size_t len) {
+	uint8_t *ptr = (uint8_t *) data;
+	uint8_t i;
+
+	for (i = 0; i < len; i++)
+		if (*ptr++)
+			return false;
+
+	return true;
+}
+
 #endif

--- a/src/lib/src/fwts_acpi_object_eval.c
+++ b/src/lib/src/fwts_acpi_object_eval.c
@@ -708,6 +708,31 @@ int fwts_method_package_elements_type(
 	return failed ? FWTS_ERROR: FWTS_OK;
 }
 
+int fwts_method_test_revision(
+	fwts_framework *fw,
+	const char *name,
+	const uint32_t cur_revision,
+	const uint32_t spec_revision)
+{
+	char method[5];
+	char tag[22];
+
+	if (strlen(name) < 4)
+		return FWTS_ERROR;
+
+	memcpy(method, name + strlen(name) - 4, 4);
+	method[4] = '\0';
+	snprintf(tag, 22, "Method%sBadRevision", method);
+
+	if (cur_revision != spec_revision) {
+		fwts_failed(fw, LOG_LEVEL_MEDIUM, tag,
+			"%s revision is not revision %" PRIu32 ".", name, spec_revision);
+		return FWTS_ERROR;
+	}
+
+	return FWTS_OK;
+}
+
 /*
  *  fwts_method_test_integer_return
  *	check if an integer object was returned

--- a/src/lib/src/fwts_acpi_tables.c
+++ b/src/lib/src/fwts_acpi_tables.c
@@ -55,6 +55,23 @@ typedef enum {
 static acpi_table_load_state acpi_tables_loaded = ACPI_TABLES_NOT_LOADED;
 
 /*
+ *  acpi_table_generic_init()
+ *  	Generic ACPI table init function
+ */
+int acpi_table_generic_init(fwts_framework *fw, char *name, fwts_acpi_table_info **table)
+{
+	if (fwts_acpi_find_table(fw, name, 0, table) != FWTS_OK) {
+		fwts_log_error(fw, "Cannot read ACPI tables.");
+		return FWTS_ERROR;
+	}
+	if (*table == NULL || (*table)->length == 0) {
+		fwts_log_error(fw, "ACPI %s table does not exist, skipping test", name);
+		return FWTS_SKIP;
+	}
+	return FWTS_OK;
+}
+
+/*
  *  fwts_acpi_find_rsdp_efi()
  *  	Get RSDP address from EFI if possible
  */

--- a/src/lib/src/fwts_acpi_tables.c
+++ b/src/lib/src/fwts_acpi_tables.c
@@ -290,11 +290,11 @@ fwts_bool fwts_acpi_is_reduced_hardware(fwts_framework *fw)
 
 	if (fwts_acpi_find_table(fw, "FACP", 0, &table) != FWTS_OK) {
 		fwts_log_error(fw, "Cannot read ACPI table FACP.");
-		return FWTS_ERROR;
+		return FWTS_BOOL_ERROR;
 	}
 	if (table == NULL) {
 		fwts_log_error(fw, "ACPI table FACP does not exist!");
-		return FWTS_ERROR;
+		return FWTS_BOOL_ERROR;
 	}
 	fadt = (const fwts_acpi_table_fadt *) table->data;
 
@@ -415,7 +415,7 @@ PRAGMA_PACK_WARN_OFF
 PRAGMA_POP
 	if (result != FWTS_OK) {
 		if ((result == FWTS_NULL_POINTER) &&
-				fwts_acpi_is_reduced_hardware(fw)) {
+				(fwts_acpi_is_reduced_hardware(fw) == FWTS_TRUE)) {
 			fwts_log_info(fw, "Ignore the missing FACS. "
 					"It is optional in hardware-reduced mode");
 		} else {

--- a/src/lib/src/fwts_acpi_tables.c
+++ b/src/lib/src/fwts_acpi_tables.c
@@ -283,10 +283,23 @@ int fwts_acpi_free_tables(void)
  *  fwts_acpi_is_reduced_hardware()
  *	Check the ACPI tables for HW_REDUCED_ACPI bit in flag field.
  */
-fwts_bool fwts_acpi_is_reduced_hardware(const fwts_acpi_table_fadt *fadt)
+fwts_bool fwts_acpi_is_reduced_hardware(fwts_framework *fw)
 {
+	fwts_acpi_table_info *table;
+	const fwts_acpi_table_fadt *fadt;
+
+	if (fwts_acpi_find_table(fw, "FACP", 0, &table) != FWTS_OK) {
+		fwts_log_error(fw, "Cannot read ACPI table FACP.");
+		return FWTS_ERROR;
+	}
+	if (table == NULL) {
+		fwts_log_error(fw, "ACPI table FACP does not exist!");
+		return FWTS_ERROR;
+	}
+	fadt = (const fwts_acpi_table_fadt *) table->data;
+
 	if ((fadt->header.revision >= 5) &&
-			(fadt->header.length >= 116)&&
+			(fadt->header.length >= 116) &&
 			(fadt->flags & FWTS_ACPI_FADT_FLAGS_HW_REDUCED_ACPI)) {
 		return FWTS_TRUE;
 	}
@@ -402,7 +415,7 @@ PRAGMA_PACK_WARN_OFF
 PRAGMA_POP
 	if (result != FWTS_OK) {
 		if ((result == FWTS_NULL_POINTER) &&
-				fwts_acpi_is_reduced_hardware(fadt)) {
+				fwts_acpi_is_reduced_hardware(fw)) {
 			fwts_log_info(fw, "Ignore the missing FACS. "
 					"It is optional in hardware-reduced mode");
 		} else {

--- a/src/lib/src/fwts_cmos.c
+++ b/src/lib/src/fwts_cmos.c
@@ -47,7 +47,6 @@ int fwts_cmos_read(const uint8_t offset, uint8_t *value)
 		goto tidy0x80;
 	}
 
-	asm("cli");
 	/* specify offset to read */
 	if (fwts_outb(offset, 0x70) != FWTS_OK) {
 		ret = FWTS_ERROR;
@@ -64,7 +63,6 @@ int fwts_cmos_read(const uint8_t offset, uint8_t *value)
 	if (fwts_inb(0x71, value) != FWTS_OK)
 		ret = FWTS_ERROR;
 tidy:
-	asm("sti");
 	(void)iopl(0);
 tidy0x80:
 	(void)ioperm(0x80, 1, 0);

--- a/src/lib/src/fwts_efi_module.c
+++ b/src/lib/src/fwts_efi_module.c
@@ -172,7 +172,7 @@ int fwts_lib_efi_runtime_open(void)
 	if (!efi_dev_name)
 		return -1;
 
-	return open(efi_dev_name, O_WRONLY | O_RDWR);
+	return open(efi_dev_name, O_RDWR);
 }
 
 /*

--- a/src/lib/src/fwts_fileio.c
+++ b/src/lib/src/fwts_fileio.c
@@ -45,7 +45,7 @@ fwts_list *fwts_file_read(FILE *fp)
 }
 
 /*
- *  fwts_file_read()
+ *  fwts_file_open_and_read()
  *	open and read file and return contents as a list of lines
  */
 fwts_list* fwts_file_open_and_read(const char *file)

--- a/src/lib/src/fwts_firmware.c
+++ b/src/lib/src/fwts_firmware.c
@@ -78,7 +78,6 @@ int fwts_firmware_features(void)
 	}
 
 	/* just check for IPMI device presence */
-
 	if (!stat("/dev/ipmi0", &ipmi_statbuf))
 		features |= FWTS_FW_FEATURE_IPMI;
 
@@ -94,14 +93,16 @@ const char *fwts_firmware_feature_string(const fwts_firmware_feature features)
 	char *p;
 	int i;
 
-	/* ensure we have enough space in str to store n names, plus n-1
-	 * separators, plus a trailing nul */
+	/*
+	 * ensure we have enough space in str to store n names, plus n-1
+	 * separators, plus a trailing nul
+	 */
 	FWTS_ASSERT((n * (sizeof(feature_names[0].name) - 1)) +
 				((n-1) * (sizeof(sep) - 1)) + 1 <
 			sizeof(str), str_too_small);
 
 	/* ensure we have a name defined for all features */
-	FWTS_ASSERT(((1 << n) - 1) == FWTS_FW_FEATURE_ALL,
+	FWTS_ASSERT(((1UL << n) - 1) == FWTS_FW_FEATURE_ALL,
 			invalid_feature_names);
 
 	for (p = str, i = 0; i < n; i++) {

--- a/src/lib/src/fwts_firmware.c
+++ b/src/lib/src/fwts_firmware.c
@@ -87,7 +87,7 @@ int fwts_firmware_features(void)
 
 const char *fwts_firmware_feature_string(const fwts_firmware_feature features)
 {
-	const int n = FWTS_ARRAY_LEN(feature_names);
+	const int n = FWTS_ARRAY_SIZE(feature_names);
 	static const char sep[] = ", ";
 	static char str[60];
 	size_t len;

--- a/src/lib/src/fwts_interactive.c
+++ b/src/lib/src/fwts_interactive.c
@@ -66,7 +66,7 @@ int fwts_printf(fwts_framework *fw, const char *fmt, ...)
 {
 	int len;
 	va_list ap;
-	
+
 	FWTS_UNUSED(fw);
 
 	va_start(ap, fmt);

--- a/src/lib/src/fwts_ioport.c
+++ b/src/lib/src/fwts_ioport.c
@@ -146,7 +146,7 @@ int fwts_outl(uint32_t port, uint32_t value)
  *  set to ~0.
  */
 int fwts_inb(uint32_t port, uint8_t *value)
-{	
+{
 	FWTS_UNUSED(port);
 
 	*value = ~0;

--- a/src/lib/src/fwts_json.c
+++ b/src/lib/src/fwts_json.c
@@ -924,9 +924,12 @@ static char *json_object_to_json_string_indent(json_object *obj, int indent)
 		if (!str)
 			return NULL;
 		tmp = str_escape((char *)obj->u.ptr);
-		if (!tmp)
+		if (!tmp) {
+			free(str);
 			return NULL;
+		}
 		str = str_append(str, tmp);
+		free(tmp);
 		if (!str)
 			return NULL;
 		str = str_append(str, "\"");

--- a/src/lib/src/fwts_json.c
+++ b/src/lib/src/fwts_json.c
@@ -755,20 +755,30 @@ static char *str_indent(char *str, int indent)
 	return str_append(str, buf);
 }
 
-static bool char_escape(const int ch)
+/*
+ *  char_escape()
+ *	convert escape char to the unescaped char to
+ *	be prefixed by \\.  If not an escape char, return 0
+ */
+static inline int char_escape(const int ch)
 {
 	switch (ch) {
 	case '"':
+		return '"';
 	case '\b':
+		return 'b';
 	case '\f':
+		return 'f';
 	case '\n':
+		return 'n';
 	case '\r':
+		return 'r';
 	case '\t':
-		return true;
+		return 't';
 	default:
 		break;
 	}
-	return false;
+	return 0;
 }
 
 static char *str_escape(char *oldstr)
@@ -784,10 +794,15 @@ static char *str_escape(char *oldstr)
 	if (!newstr)
 		return NULL;
 
-	for (oldptr = oldstr, newptr = newstr; *oldptr; oldptr++, newptr++) {
-		if (char_escape(*oldptr))
+	for (oldptr = oldstr, newptr = newstr; *oldptr; oldptr++) {
+		const int esc = char_escape(*oldptr);
+
+		if (esc) {
 			*(newptr++) = '\\';
-		*newptr = *oldptr;
+			*(newptr++) = esc;
+		} else {
+			*(newptr++) = *oldptr;
+		}
 	}
 	*newptr = '\0';
 	return newstr;

--- a/src/lib/src/fwts_oops.c
+++ b/src/lib/src/fwts_oops.c
@@ -71,7 +71,7 @@ static void fwts_klog_stack_dump(
 		 * We are looking for an Oops message within 5 lines of a "BUG:"
 		 * or we've got a WARN_ON then, OK, otherwise abort.
 		 */
-		if ((lines > 5) && 
+		if ((lines > 5) &&
 		    (!(dumpable & (FWTS_OOPS_GOT_OOPS | FWTS_OOPS_GOT_WARN_ON))))
 			return;
 

--- a/src/lib/src/fwts_safe_mem.c
+++ b/src/lib/src/fwts_safe_mem.c
@@ -48,12 +48,15 @@ static void sig_handler(int dummy)
  */
 int OPTIMIZE0 fwts_safe_memcpy(void *dst, const void *src, const size_t n)
 {
+	size_t i;
+
 	if (sigsetjmp(jmpbuf, 1) != 0)
 		return FWTS_ERROR;
 
 	fwts_sig_handler_set(SIGSEGV, sig_handler, &old_segv_action);
 	fwts_sig_handler_set(SIGBUS, sig_handler, &old_bus_action);
-	memcpy(dst, src, n);
+	for (i = n; i; --i)
+		*(char *)dst++ = *(char *)src++;
 	fwts_sig_handler_restore(SIGSEGV, &old_segv_action);
 	fwts_sig_handler_restore(SIGBUS, &old_bus_action);
 

--- a/src/lib/src/fwts_tpm.c
+++ b/src/lib/src/fwts_tpm.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 Canonical
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "fwts.h"
+#include "fwts_tpm.h"
+
+/*
+ *  fwts_tpm_data_hexdump
+ *	hex dump of a tpm event log data
+ */
+void fwts_tpm_data_hexdump(fwts_framework *fw, uint8_t *data, size_t size, char *str)
+{
+	size_t i;
+
+	fwts_log_info_verbatim(fw, "%s: ", str);
+	for (i = 0; i < size; i += 16) {
+		char buffer[128];
+		size_t left = size - i;
+
+		fwts_dump_raw_data(buffer, sizeof(buffer), data + i, i, left > 16 ? 16 : left);
+		fwts_log_info_verbatim(fw, "%s", buffer + 2);
+	}
+}
+
+/*
+ *  fwts_tpm_evlog_type_to_string
+ *	get hash size
+ */
+uint8_t fwts_tpm_get_hash_size (TPM2_ALG_ID hash)
+{
+	uint8_t sz;
+
+	switch (hash) {
+	case TPM2_ALG_SHA1:
+		sz = TPM2_SHA1_DIGEST_SIZE;
+		break;
+	case TPM2_ALG_SHA256:
+		sz = TPM2_SHA256_DIGEST_SIZE;
+		break;
+	case TPM2_ALG_SHA384:
+		sz = TPM2_SHA384_DIGEST_SIZE;
+		break;
+	case TPM2_ALG_SHA512:
+		sz = TPM2_SHA512_DIGEST_SIZE;
+		break;
+	default:
+		sz = 0;
+		break;
+	}
+
+	return sz;
+}

--- a/src/lib/src/fwts_uefi.c
+++ b/src/lib/src/fwts_uefi.c
@@ -541,45 +541,22 @@ bool fwts_uefi_efivars_iface_exist(void)
 
 /*
  *  fwts_uefi_rt_support_status_get()
- *	get the status of runtime service support and the value of
- *	the RuntimeServicesSupported variable
+ *	get the status of runtime service support.
+ *
+ *	Since UEFI 2.8 Errata A the EFI_RT_PROPERTIES_TABLE configuration table
+ *	can be used to indicate which UEFI runtime services are not implemented
+ *	via the bitmask RuntimeServicesSupported. If the table is not present,
+ *	all runtime services are to be considered available. Since Linux 5.11
+ *	this bitmask can be read via an IOCTL call. Before Linux 5.11 the value
+ *	cannot be determined.
  */
-void fwts_uefi_rt_support_status_get(int fd, bool *getvar_supported, uint32_t *var_rtsupported)
+void fwts_uefi_rt_support_status_get(int fd, uint32_t *var_rtsupported)
 {
 	long ioret;
-	struct efi_getvariable getvariable;
-	uint64_t status = ~0ULL;
-	uint8_t data[512];
-	uint64_t getdatasize = sizeof(data);
-	*var_rtsupported = 0xFFFF;
 
-	uint32_t attributes = FWTS_UEFI_VAR_NON_VOLATILE |
-				FWTS_UEFI_VAR_BOOTSERVICE_ACCESS |
-				FWTS_UEFI_VAR_RUNTIME_ACCESS;
-	static uint16_t varname[] = {'R', 'u', 'n', 't', 'i', 'm', 'e', 'S', 'e',
-				'r', 'v', 'i', 'c', 'e', 's', 'S', 'u', 'p',
-				'p', 'o', 'r', 't', 'e', 'd', '\0'};
-	EFI_GUID global_var_guid = EFI_GLOBAL_VARIABLE;
-	getvariable.VariableName = varname;
-	getvariable.VendorGuid = &global_var_guid;
-	getvariable.Attributes = &attributes;
-	getvariable.DataSize = &getdatasize;
-	getvariable.Data = data;
-	getvariable.status = &status;
-
-	ioret = ioctl(fd, EFI_RUNTIME_GET_VARIABLE, &getvariable);
-	if (ioret == -1) {
-		if (status == EFI_NOT_FOUND) {
-			*getvar_supported = true;
-		} else {
-			*getvar_supported = false;
-		}
-		return;
-	}
-
-	*getvar_supported = true;
-	*var_rtsupported = data[0] | data[1] << 8;
+	ioret = ioctl(fd, EFI_RUNTIME_GET_SUPPORTED_MASK, var_rtsupported);
+	if (ioret == -1)
+		*var_rtsupported = EFI_RT_SUPPORTED_ALL;
 
 	return;
-
 }

--- a/src/libfwtsacpica/fwts_acpica.c
+++ b/src/libfwtsacpica/fwts_acpica.c
@@ -60,7 +60,7 @@
 #define ACPI_ADR_SPACE_USER_DEFINED1	(0x80)
 #define ACPI_ADR_SPACE_USER_DEFINED2	(0xE4)
 
-/* 
+/*
  *  Semaphore accounting info
  */
 typedef struct {

--- a/src/pci/maxreadreq/maxreadreq.c
+++ b/src/pci/maxreadreq/maxreadreq.c
@@ -63,6 +63,7 @@ static int maxreadreq_test1(fwts_framework *fw)
 		int fd;
 		ssize_t n;
 		uint8_t offset = 0;
+		uint16_t vendor_id;
 
 		if (entry->d_name[0] == '.')
 			continue;
@@ -95,6 +96,12 @@ static int maxreadreq_test1(fwts_framework *fw)
 		/* Ignore Audio Device */
 		if ((config[FWTS_PCI_CONFIG_CLASS_CODE] == FWTS_PCI_CLASS_CODE_MULTIMEDIA_CONTROLLER) &&
 		    (config[FWTS_PCI_CONFIG_SUBCLASS] == FWTS_PCI_SUBCLASS_CODE_AUDIO_DEVICE))
+			continue;
+
+		/* Ignore Intel's Video Device */
+		vendor_id = config[FWTS_PCI_CONFIG_VENDOR_ID] + ((config[FWTS_PCI_CONFIG_VENDOR_ID  + 1]) << 8);
+		if ((config[FWTS_PCI_CONFIG_CLASS_CODE] == FWTS_PCI_CLASS_CODE_DISPLAY_CONTROLLER) &&
+		    (vendor_id == FWTS_PCI_INTEL_VENDOR_ID))
 			continue;
 
 		/* config region too small, do next */

--- a/src/sbbr/fadt/fadt.c
+++ b/src/sbbr/fadt/fadt.c
@@ -378,7 +378,7 @@ static int fadt_sbbr_profile_test3(fwts_framework *fw)
 
 	fwts_log_info(fw, "FADT Preferred PM Profile: %hhu (%s)",
 		fadt->preferred_pm_profile,
-		FWTS_ACPI_FADT_PREFERRED_PM_PROFILE(fadt->preferred_pm_profile));
+		fwts_acpi_fadt_preferred_pm_profile(fadt->preferred_pm_profile));
 
 	if ((fadt->preferred_pm_profile == SBBR_ENT_SERVER)  ||
 	(fadt->preferred_pm_profile == SBBR_SOHO_SERVER) ||

--- a/src/sbbr/fadt/fadt.c
+++ b/src/sbbr/fadt/fadt.c
@@ -381,8 +381,8 @@ static int fadt_sbbr_profile_test3(fwts_framework *fw)
 		fwts_acpi_fadt_preferred_pm_profile(fadt->preferred_pm_profile));
 
 	if ((fadt->preferred_pm_profile == SBBR_ENT_SERVER)  ||
-	(fadt->preferred_pm_profile == SBBR_SOHO_SERVER) ||
-	(fadt->preferred_pm_profile == SBBR_PERF_SERVER))
+            (fadt->preferred_pm_profile == SBBR_SOHO_SERVER) ||
+            (fadt->preferred_pm_profile == SBBR_PERF_SERVER))
 		fwts_passed(fw, "FADT has a recommended server PM profile.");
 	else
 		fwts_failed(fw, LOG_LEVEL_MEDIUM, "fadt_profile:", "FADT preferred PM profile is not recommended.");

--- a/src/sbbr/fadt/fadt.c
+++ b/src/sbbr/fadt/fadt.c
@@ -93,11 +93,12 @@ static int fadt_sbbr_reduced_hw_test2(fwts_framework *fw)
 	uint32_t flag_mask;
 
 	rhw = fwts_acpi_is_reduced_hardware(fw);
-	if (rhw == 0)
+	if (rhw == FWTS_FALSE)
 		fwts_failed(fw, LOG_LEVEL_CRITICAL, "fadt_reduced_hw:", "FADT indicates ACPI is not in reduced hardware mode.");
-	else
+	else if(rhw == FWTS_TRUE)
 		fwts_passed(fw, "FADT indicates ACPI is in reduced hardware mode.");
-
+	else
+		fwts_failed(fw, LOG_LEVEL_HIGH, "fadt_reduced_hw:", "ACPI table reads error.");
 
 	if (!rhw)
 		return FWTS_OK;

--- a/src/sbbr/fadt/fadt.c
+++ b/src/sbbr/fadt/fadt.c
@@ -92,7 +92,7 @@ static int fadt_sbbr_reduced_hw_test2(fwts_framework *fw)
 	static const fwts_acpi_gas null_gas;
 	uint32_t flag_mask;
 
-	rhw = fwts_acpi_is_reduced_hardware(fadt);
+	rhw = fwts_acpi_is_reduced_hardware(fw);
 	if (rhw == 0)
 		fwts_failed(fw, LOG_LEVEL_CRITICAL, "fadt_reduced_hw:", "FADT indicates ACPI is not in reduced hardware mode.");
 	else

--- a/src/tpm/tpmevlog/tpmevlog.c
+++ b/src/tpm/tpmevlog/tpmevlog.c
@@ -1,0 +1,446 @@
+/*
+ * Copyright (C) 2020 Canonical
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "fwts.h"
+
+#include <sys/types.h>
+#include <dirent.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include "fwts_tpm.h"
+
+#define FWTS_TPM_LOG_DIR_PATH	"/sys/kernel/security"
+
+static int tpmevlog_pcrindex_value_check(fwts_framework *fw, const uint32_t pcr)
+{
+	/*
+	 * Current PCRs defined from 0 to 16, and 23 is for application support,
+	 * defined from TCG PC Client Platform Firmware Profile Specification
+	 * https://trustedcomputinggroup.org/resource/pc-client-specific-platform-firmware-profile-specification/
+	 * 2.3.4 PCR Usage
+	 */
+	if ((pcr > 16) && (pcr != 23)) {
+		fwts_failed(fw, LOG_LEVEL_HIGH, "PCRIndexValue",
+			"The PCR Index value is undefined, 0x%8.8" PRIx32 ".",
+			pcr);
+		return FWTS_ERROR;
+	}
+
+	return FWTS_OK;
+}
+
+static int tpmevlog_eventtype_check(fwts_framework *fw, const fwts_tpmlog_event_type event_type)
+{
+
+	switch (event_type) {
+	case EV_PREBOOT_CERT:
+	case EV_POST_CODE:
+	case EV_UNUSED:
+	case EV_NO_ACTION:
+	case EV_SEPARATOR:
+	case EV_ACTION:
+	case EV_EVENT_TAG:
+	case EV_S_CRTM_CONTENTS:
+	case EV_S_CRTM_VERSION:
+	case EV_CPU_MICROCODE:
+	case EV_PLATFORM_CONFIG_FLAGS:
+	case EV_TABLE_OF_DEVICES:
+	case EV_IPL:
+	case EV_IPL_PARTITION_DATA:
+	case EV_NONHOST_CODE:
+	case EV_NONHOST_CONFIG:
+	case EV_NONHOST_INFO:
+	case EV_OMIT_BOOT_DEVICE_EVENTS:
+	case EV_EFI_EVENT_BASE:
+	case EV_EFI_VARIABLE_DRIVER_CONFIG:
+	case EV_EFI_VARIABLE_BOOT:
+	case EV_EFI_BOOT_SERVICES_APPLICATION:
+	case EV_EFI_BOOT_SERVICES_DRIVER:
+	case EV_EFI_RUNTIME_SERVICES_DRIVER:
+	case EV_EFI_GPT_EVENT:
+	case EV_EFI_ACTION:
+	case EV_EFI_PLATFORM_FIRMWARE_BLOB:
+	case EV_EFI_HANDOFF_TABLES:
+	case EV_EFI_HCRTM_EVENT:
+	case EV_EFI_VARIABLE_AUTHORITY:
+		return FWTS_OK;
+	default:
+		fwts_failed(fw, LOG_LEVEL_HIGH, "PCREventType",
+			"The Event Type is undefined, 0x%8.8" PRIx32 ".",
+			event_type);
+		return FWTS_ERROR;
+	}
+
+	return FWTS_OK;
+}
+
+static int tpmevlog_algid_check(fwts_framework *fw, const TPM2_ALG_ID hash)
+{
+
+	switch (hash) {
+	case TPM2_ALG_RSA:
+	case TPM2_ALG_TDES:
+	case TPM2_ALG_SHA1:
+	case TPM2_ALG_HMAC:
+	case TPM2_ALG_AES:
+	case TPM2_ALG_MGF1:
+	case TPM2_ALG_KEYEDHASH:
+	case TPM2_ALG_XOR:
+	case TPM2_ALG_SHA256:
+	case TPM2_ALG_SHA384:
+	case TPM2_ALG_SHA512:
+	case TPM2_ALG_NULL:
+	case TPM2_ALG_SM3_256:
+	case TPM2_ALG_SM4:
+	case TPM2_ALG_RSASSA:
+	case TPM2_ALG_RSAES:
+	case TPM2_ALG_RSAPSS:
+	case TPM2_ALG_OAEP:
+	case TPM2_ALG_ECDSA:
+	case TPM2_ALG_ECDH:
+	case TPM2_ALG_ECDAA:
+	case TPM2_ALG_SM2:
+	case TPM2_ALG_ECSCHNORR:
+	case TPM2_ALG_ECMQV:
+	case TPM2_ALG_KDF1_SP800_56A:
+	case TPM2_ALG_KDF2:
+	case TPM2_ALG_KDF1_SP800_108:
+	case TPM2_ALG_ECC:
+	case TPM2_ALG_SYMCIPHER:
+	case TPM2_ALG_CAMELLIA:
+	case TPM2_ALG_CMAC:
+	case TPM2_ALG_CTR:
+	case TPM2_ALG_SHA3_256:
+	case TPM2_ALG_SHA3_384:
+	case TPM2_ALG_SHA3_512:
+	case TPM2_ALG_OFB:
+	case TPM2_ALG_CBC:
+	case TPM2_ALG_CFB:
+	case TPM2_ALG_ECB:
+		return FWTS_OK;
+	default:
+		fwts_failed(fw, LOG_LEVEL_HIGH, "AlgorithmID",
+			"The AlgorithmID is undefined, 0x%4.4" PRIx16 ".",
+			hash);
+		return FWTS_ERROR;
+	}
+
+	return FWTS_OK;
+}
+
+static int tpmevlog_v2_check(fwts_framework *fw, uint8_t *data, size_t len)
+{
+	int ret = FWTS_OK;
+	size_t len_remain = len;
+	uint8_t *pdata = data;
+	int i = 0;
+	uint8_t vendor_info_size = 0;
+	uint8_t hash_size = 0;
+	uint32_t event_size = 0;
+
+	/* specid_event_check */
+	if (len < sizeof(fwts_pc_client_pcr_event)) {
+		fwts_failed(fw, LOG_LEVEL_MEDIUM, "SpecidEventLength",
+				"The length of the Specid event is %zd bytes "
+				"is smaller than the PCClientPCREvent %zd bytes.",
+				len_remain,
+				sizeof(fwts_pc_client_pcr_event));
+		return FWTS_ERROR;
+	}
+
+	fwts_pc_client_pcr_event *pc_event = (fwts_pc_client_pcr_event *)pdata;
+	ret = tpmevlog_pcrindex_value_check(fw, pc_event->pcr_index);
+	if (ret != FWTS_OK)
+		return ret;
+	ret = tpmevlog_eventtype_check(fw, pc_event->event_type);
+	if (ret != FWTS_OK)
+		return ret;
+	for (i = 0; i < TPM2_SHA1_DIGEST_SIZE; i++) {
+		if (pc_event->digest[i] != 0) {
+			fwts_failed(fw, LOG_LEVEL_HIGH, "SpecIdEvDigest",
+				"The digest filed of SpecId event should be all zero.");
+			fwts_tpm_data_hexdump(fw, pc_event->digest, sizeof(pc_event->digest), "Digest");
+		}
+	}
+
+	pdata += sizeof(fwts_pc_client_pcr_event);
+	len_remain -= sizeof(fwts_pc_client_pcr_event);
+
+	/* check the data length specid event */
+	if (len_remain < sizeof(fwts_efi_spec_id_event)) {
+		fwts_failed(fw, LOG_LEVEL_MEDIUM, "SpecidEventLength",
+				"The length of the Specid event is %zd bytes "
+				"is smaller than the SpecId event %zd bytes.",
+				len_remain,
+				sizeof(fwts_efi_spec_id_event));
+		return FWTS_ERROR;
+	}
+
+	fwts_efi_spec_id_event *specid_evcent = (fwts_efi_spec_id_event *)pdata;
+	if (strcmp((char *)specid_evcent->signature, FWTS_TPM_EVENTLOG_V2_SIGNATURE) != 0) {
+		fwts_failed(fw, LOG_LEVEL_HIGH, "SpecIdEvSignature",
+			"The signature of SpecId event is not the same as expected "
+			"Spec ID Event03, got %s.",
+			(char *)specid_evcent->signature);
+		return FWTS_ERROR;
+	}
+
+	/*
+	 * Check the platform class value which defined in TCG ACPI Specification,
+	 * 0 for client platforms, 1 for server platforms.
+	 */
+	if (specid_evcent->platform_class > 1) {
+		fwts_failed(fw, LOG_LEVEL_HIGH, "SpecIdEvPlatformClass",
+			"The PlatformClass value of SpecId event is unexpected "
+			"0 for client platforms, 1 for server platforms, "
+			"got 0x%8.8" PRIx32 ".", specid_evcent->platform_class);
+		return FWTS_ERROR;
+	}
+
+	if (specid_evcent->uintn_size < 1 || specid_evcent->uintn_size > 2) {
+		fwts_failed(fw, LOG_LEVEL_HIGH, "SpecIdEvUINTNFields",
+			"The size of the UINTN fieldsof SpecId event is unexpected "
+			"0x01 indicates UINT32 and 0x02 indicates UINT64, "
+			"got 0x%" PRIx8 ".", specid_evcent->uintn_size);
+		return FWTS_ERROR;
+	}
+
+	if (specid_evcent->number_of_alg < 1) {
+		fwts_failed(fw, LOG_LEVEL_HIGH, "SpecIdEvAlgNumber",
+			"The number of Hash algorithms of SpecId event must "
+			"be set to a value of 0x01 or greater "
+			"got 0x%" PRIx8 ".", specid_evcent->number_of_alg);
+		return FWTS_ERROR;
+	}
+
+	pdata += sizeof(fwts_efi_spec_id_event);
+	len_remain -= sizeof(fwts_efi_spec_id_event);
+	fwts_spec_id_event_alg_sz *alg_sz = (fwts_spec_id_event_alg_sz *)pdata;
+	for (i = 0; i < specid_evcent->number_of_alg; i++) {
+		if (len_remain < sizeof(fwts_spec_id_event_alg_sz)) {
+			fwts_failed(fw, LOG_LEVEL_MEDIUM, "SpecidEventLength",
+					"The length of the Specid event is %zd bytes "
+					"is smaller than AlgorithmSize %zd bytes.",
+					len_remain,
+					sizeof(fwts_spec_id_event_alg_sz));
+			return FWTS_ERROR;
+		}
+
+		ret = tpmevlog_algid_check(fw, alg_sz->algorithm_id);
+		if (ret != FWTS_OK)
+			return ret;
+
+		pdata += sizeof(fwts_spec_id_event_alg_sz);
+		len_remain -= sizeof(fwts_spec_id_event_alg_sz);
+		alg_sz = (fwts_spec_id_event_alg_sz *)pdata;
+	}
+
+	vendor_info_size = *(uint8_t *)pdata;
+	pdata += sizeof(vendor_info_size);
+	len_remain -= sizeof(vendor_info_size);
+	if (vendor_info_size > 0) {
+		if (len_remain < vendor_info_size) {
+			fwts_failed(fw, LOG_LEVEL_MEDIUM, "SpecidEventLength",
+					"The remain length of the Specid event is "
+					"is too small (%zd bytes) for "
+					"vendor info size.",
+					len_remain);
+			return FWTS_ERROR;
+		}
+		len_remain -= vendor_info_size;
+		pdata += vendor_info_size;
+	}
+
+	/* Check the Crypto agile log format event */
+	while (len_remain > 0) {
+		if (len_remain < sizeof(fwts_tcg_pcr_event2)) {
+			fwts_failed(fw, LOG_LEVEL_MEDIUM, "EventV2Length",
+					"The length of the event2 is %zd bytes "
+					"is smaller than the tcg pcr event2 %zd bytes.",
+					len_remain,
+					sizeof(fwts_tcg_pcr_event2));
+			return FWTS_ERROR;
+		}
+
+		fwts_tcg_pcr_event2 *pcr_event2 = (fwts_tcg_pcr_event2 *)pdata;
+		ret = tpmevlog_pcrindex_value_check(fw, pcr_event2->pcr_index);
+		if (ret != FWTS_OK)
+			return ret;
+		ret = tpmevlog_eventtype_check(fw, pcr_event2->event_type);
+		if (ret != FWTS_OK)
+			return ret;
+
+		pdata += sizeof(fwts_tcg_pcr_event2);
+		len_remain -= sizeof(fwts_tcg_pcr_event2);
+		for (i = 0; i < pcr_event2->digests_count; i++) {
+
+			hash_size = 0;
+			TPM2_ALG_ID alg_id = *(TPM2_ALG_ID *)pdata;
+
+			ret = tpmevlog_algid_check(fw, alg_id);
+			if (ret != FWTS_OK)
+				return ret;
+
+			pdata += sizeof(TPM2_ALG_ID);
+			len_remain -= sizeof(TPM2_ALG_ID);
+
+			hash_size = fwts_tpm_get_hash_size(alg_id);
+			if (!hash_size) {
+				fwts_failed(fw, LOG_LEVEL_MEDIUM, "EventV2HashSize",
+						"The hash sie of the event2 is %zd bytes "
+						"is smaller than the tcg pcr event2 %zd bytes.",
+						len_remain,
+						sizeof(fwts_tcg_pcr_event2));
+				return FWTS_ERROR;
+			}
+
+			pdata += hash_size;
+			len_remain -= hash_size;
+		}
+
+		event_size = *(uint32_t *)pdata;
+
+		if (len_remain < event_size) {
+			fwts_failed(fw, LOG_LEVEL_MEDIUM, "EventV2Length",
+					"The remain length of the event2 is %zd bytes "
+					"is smaller than required event2 length %zd bytes.",
+					len_remain,
+					sizeof(event_size));
+			return FWTS_ERROR;
+		}
+		pdata += (event_size + sizeof(event_size));
+		len_remain -= (event_size + sizeof(event_size));
+
+	}
+	fwts_passed(fw, "Check TPM crypto agile event log test passed.");
+	return FWTS_OK;
+}
+
+static uint8_t *tpmevlog_load_file(const int fd, size_t *length)
+{
+	uint8_t *ptr = NULL, *tmp;
+	size_t size = 0;
+	char buffer[4096];
+
+	*length = 0;
+
+	for (;;) {
+		ssize_t n = read(fd, buffer, sizeof(buffer));
+
+		if (n == 0)
+			break;
+		if (n < 0) {
+			if (errno != EINTR && errno != EAGAIN) {
+				free(ptr);
+				return NULL;
+			}
+			continue;
+		}
+		if (n > (ssize_t)sizeof(buffer))
+			goto err;
+		if (size + n > 0xffffffff)
+			goto err;
+
+		if ((tmp = (uint8_t*)realloc(ptr, size + n + 1)) == NULL) {
+			free(ptr);
+			return NULL;
+		}
+		ptr = tmp;
+		memcpy(ptr + size, buffer, n);
+		size += n;
+	}
+
+	if (!ptr || !size)
+		goto err_no_data;
+
+	*length = size;
+	return ptr;
+
+err:
+	free(ptr);
+err_no_data:
+	*length = 0;
+	return NULL;
+}
+
+static int tpmevlog_test1(fwts_framework *fw)
+{
+	DIR *dir;
+	struct dirent *tpmdir;
+	bool tpm_logfile_found = false;
+
+	if (!(dir = opendir(FWTS_TPM_LOG_DIR_PATH))) {
+		fwts_log_info(fw, "Cannot find the TPM event log. Aborted.");
+		return FWTS_ABORTED;
+	}
+
+	do {
+		tpmdir = readdir(dir);
+		if (tpmdir && strstr(tpmdir->d_name, "tpm")) {
+			char path[PATH_MAX];
+			uint8_t *data;
+			int fd;
+			size_t length;
+
+			fwts_log_nl(fw);
+			fwts_log_info_verbatim(fw, "%s", tpmdir->d_name);
+
+			snprintf(path, sizeof(path), FWTS_TPM_LOG_DIR_PATH "/%s/binary_bios_measurements", tpmdir->d_name);
+
+			if ((fd = open(path, O_RDONLY)) >= 0) {
+				data = tpmevlog_load_file(fd, &length);
+				tpm_logfile_found = true;
+				if (data == NULL) {
+					fwts_log_info(fw, "Cannot load the TPM event logs. Aborted.");
+					(void)closedir(dir);
+					(void)close(fd);
+					return FWTS_ABORTED;
+				} else {
+					/* check if the TPM2 eventlog */
+					if (strstr((char *)(data + sizeof(fwts_pc_client_pcr_event)), FWTS_TPM_EVENTLOG_V2_SIGNATURE))
+						tpmevlog_v2_check(fw, data, length);
+
+					free(data);
+				}
+				(void)close(fd);
+			}
+		}
+	} while (tpmdir);
+
+	(void)closedir(dir);
+
+	if (!tpm_logfile_found) {
+		fwts_log_info(fw, "Cannot find the TPM event log. Aborted.");
+		return FWTS_ABORTED;
+	}
+	return FWTS_OK;
+}
+
+static fwts_framework_minor_test tpmevlog_tests[] = {
+	{ tpmevlog_test1, "Sanity check TPM event log." },
+	{ NULL, NULL }
+};
+
+static fwts_framework_ops tpmevlog_ops = {
+	.description = "Sanity check TPM event log.",
+	.minor_tests = tpmevlog_tests
+};
+
+FWTS_REGISTER("tpmevlog", &tpmevlog_ops, FWTS_TEST_ANYTIME, FWTS_FLAG_ROOT_PRIV)

--- a/src/uefi/securebootcert/securebootcert.c
+++ b/src/uefi/securebootcert/securebootcert.c
@@ -487,7 +487,7 @@ static int securebootcert_test1(fwts_framework *fw)
 				"Secureboot or deployed mode on, but the variable KEK not found.");
 	} else {
 		if (!(var_found & VAR_DB_FOUND))
-			fwts_log_info(fw, "Not in readiness for secureboot, variable DB not found.");		
+			fwts_log_info(fw, "Not in readiness for secureboot, variable DB not found.");
 		if (!(var_found & VAR_KEK_FOUND))
 			fwts_log_info(fw, "Not in readiness for secureboot, variable KEK not found.");
 	}

--- a/src/uefi/uefirtmisc/uefirtmisc.c
+++ b/src/uefi/uefirtmisc/uefirtmisc.c
@@ -258,8 +258,7 @@ static int uefirtmisc_test4(fwts_framework *fw)
 	ioret = ioctl(fd, EFI_RUNTIME_GET_NEXTHIGHMONOTONICCOUNT, &getnexthighmonotoniccount);
 	if (ioret == -1) {
 		if (status == EFI_UNSUPPORTED) {
-			if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_NEXT_HIGH_MONOTONIC_COUNT)
-				|| (var_runtimeservicessupported == 0)) {
+			if (var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_NEXT_HIGH_MONOTONIC_COUNT) {
 				fwts_failed(fw, LOG_LEVEL_HIGH,
 					"UEFIRuntimeGetNextHighMonotonicCount",
 					"Get the GetNextHighMonotonicCount runtime "
@@ -275,8 +274,7 @@ static int uefirtmisc_test4(fwts_framework *fw)
 				fwts_skipped(fw, "Unknown error occurred, skip test.");
 				return FWTS_SKIP;
 			}
-			if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_NEXT_HIGH_MONOTONIC_COUNT)
-				|| (var_runtimeservicessupported == 0)) {
+			if (var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_NEXT_HIGH_MONOTONIC_COUNT) {
 				fwts_passed(fw, "UEFI GetNextHighMonotonicCount runtime "
 					"service supported status test passed.");
 			} else {
@@ -292,8 +290,7 @@ static int uefirtmisc_test4(fwts_framework *fw)
 			fwts_skipped(fw, "Unknown error occurred, skip test.");
 			return FWTS_SKIP;
 		}
-		if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_NEXT_HIGH_MONOTONIC_COUNT)
-			|| (var_runtimeservicessupported == 0)) {
+		if (var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_NEXT_HIGH_MONOTONIC_COUNT) {
 			fwts_passed(fw, "UEFI GetNextHighMonotonicCount runtime "
 				"service supported status test passed.");
 		} else {

--- a/src/uefi/uefirtmisc/uefirtmisc.c
+++ b/src/uefi/uefirtmisc/uefirtmisc.c
@@ -245,22 +245,12 @@ static int uefirtmisc_test4(fwts_framework *fw)
 {
 	long ioret;
 	uint64_t status;
-	bool getvar_supported;
 	uint32_t var_runtimeservicessupported;
 
 	struct efi_getnexthighmonotoniccount getnexthighmonotoniccount;
 	uint32_t highcount;
 
-	fwts_uefi_rt_support_status_get(fd, &getvar_supported,
-			&var_runtimeservicessupported);
-	if (!getvar_supported || (var_runtimeservicessupported == 0xFFFF)) {
-		fwts_skipped(fw, "Cannot get the RuntimeServicesSupported "
-				"variable, maybe the runtime service "
-				"GetVariable is not supported or "
-				"RuntimeServicesSupported not provided by "
-				"firmware.");
-		return FWTS_SKIP;
-	}
+	fwts_uefi_rt_support_status_get(fd, &var_runtimeservicessupported);
 
 	getnexthighmonotoniccount.HighCount = &highcount;
 	getnexthighmonotoniccount.status = &status;

--- a/src/uefi/uefirttime/uefirttime.c
+++ b/src/uefi/uefirttime/uefirttime.c
@@ -1162,8 +1162,7 @@ static int uefirttime_test38(fwts_framework *fw)
 	ioret = ioctl(fd, EFI_RUNTIME_GET_TIME, &gettime);
 	if (ioret == -1) {
 		if (status == EFI_UNSUPPORTED) {
-			if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_TIME)
-				|| (var_runtimeservicessupported == 0)) {
+			if (var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_TIME) {
 				fwts_failed(fw, LOG_LEVEL_HIGH, "UEFIRuntimeGetTime",
 					"Get the GetTime runtime service supported "
 					"via RuntimeServicesSupported variable. "
@@ -1177,8 +1176,7 @@ static int uefirttime_test38(fwts_framework *fw)
 				fwts_skipped(fw, "Unknown error occurred, skip test.");
 				return FWTS_SKIP;
 			}
-			if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_TIME)
-				|| (var_runtimeservicessupported == 0)) {
+			if (var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_TIME) {
 				fwts_passed(fw, "UEFI GetTime runtime service "
 					"supported status test passed.");
 			} else {
@@ -1193,8 +1191,7 @@ static int uefirttime_test38(fwts_framework *fw)
 			fwts_skipped(fw, "Unknown error occurred, skip test.");
 			return FWTS_SKIP;
 		}
-		if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_TIME)
-			|| (var_runtimeservicessupported == 0)) {
+		if (var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_TIME) {
 			fwts_passed(fw, "UEFI GetTime runtime service "
 				"supported status test passed.");
 		} else {
@@ -1212,8 +1209,7 @@ static int uefirttime_test38(fwts_framework *fw)
 	ioret = ioctl(fd, EFI_RUNTIME_SET_TIME, &settime);
 	if (ioret == -1) {
 		if (status == EFI_UNSUPPORTED) {
-			if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_SET_TIME)
-				|| (var_runtimeservicessupported == 0)) {
+			if (var_runtimeservicessupported & EFI_RT_SUPPORTED_SET_TIME) {
 				fwts_failed(fw, LOG_LEVEL_HIGH, "UEFIRuntimeSetTime",
 					"Get the SetTime runtime service supported "
 					"via RuntimeServicesSupported variable. "
@@ -1227,8 +1223,7 @@ static int uefirttime_test38(fwts_framework *fw)
 				fwts_skipped(fw, "Unknown error occurred, skip test.");
 				return FWTS_SKIP;
 			}
-			if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_SET_TIME)
-				|| (var_runtimeservicessupported == 0)) {
+			if (var_runtimeservicessupported & EFI_RT_SUPPORTED_SET_TIME) {
 				fwts_passed(fw, "UEFI SetTime runtime service "
 					"supported status test passed.");
 			} else {
@@ -1243,8 +1238,7 @@ static int uefirttime_test38(fwts_framework *fw)
 			fwts_skipped(fw, "Unknown error occurred, skip test.");
 			return FWTS_SKIP;
 		}
-		if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_SET_TIME)
-			|| (var_runtimeservicessupported == 0)) {
+		if (var_runtimeservicessupported & EFI_RT_SUPPORTED_SET_TIME) {
 			fwts_passed(fw, "UEFI SetTime runtime service "
 				"supported status test passed.");
 		} else {
@@ -1263,8 +1257,7 @@ static int uefirttime_test38(fwts_framework *fw)
 	ioret = ioctl(fd, EFI_RUNTIME_SET_WAKETIME, &setwakeuptime);
 	if (ioret == -1) {
 		if (status == EFI_UNSUPPORTED) {
-			if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_SET_WAKEUP_TIME)
-				|| (var_runtimeservicessupported == 0)) {
+			if (var_runtimeservicessupported & EFI_RT_SUPPORTED_SET_WAKEUP_TIME) {
 				fwts_failed(fw, LOG_LEVEL_HIGH, "UEFIRuntimeSetWakeupTime",
 					"Get the SetWakeupTime runtime service supported "
 					"via RuntimeServicesSupported variable. "
@@ -1279,8 +1272,7 @@ static int uefirttime_test38(fwts_framework *fw)
 				fwts_skipped(fw, "Unknown error occurred, skip test.");
 				return FWTS_SKIP;
 			}
-			if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_SET_WAKEUP_TIME)
-				|| (var_runtimeservicessupported == 0)) {
+			if (var_runtimeservicessupported & EFI_RT_SUPPORTED_SET_WAKEUP_TIME) {
 				fwts_passed(fw, "UEFI SetWakeupTime runtime service "
 					"supported status test passed.");
 			} else {
@@ -1295,8 +1287,7 @@ static int uefirttime_test38(fwts_framework *fw)
 			fwts_skipped(fw, "Unknown error occurred, skip test.");
 			return FWTS_SKIP;
 		}
-		if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_SET_WAKEUP_TIME)
-			|| (var_runtimeservicessupported == 0)) {
+		if (var_runtimeservicessupported & EFI_RT_SUPPORTED_SET_WAKEUP_TIME) {
 			fwts_passed(fw, "UEFI SetWakeupTime runtime service "
 				"supported status test passed.");
 		} else {
@@ -1315,8 +1306,7 @@ static int uefirttime_test38(fwts_framework *fw)
 	ioret = ioctl(fd, EFI_RUNTIME_GET_WAKETIME, &getwakeuptime);
 	if (ioret == -1) {
 		if (status == EFI_UNSUPPORTED) {
-			if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_WAKEUP_TIME)
-				|| (var_runtimeservicessupported == 0)) {
+			if (var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_WAKEUP_TIME) {
 				fwts_failed(fw, LOG_LEVEL_HIGH, "UEFIRuntimeGetWakeupTime",
 					"Get the GetWakeupTime runtime service supported "
 					"via RuntimeServicesSupported variable. "
@@ -1330,8 +1320,7 @@ static int uefirttime_test38(fwts_framework *fw)
 				fwts_skipped(fw, "Unknown error occurred, skip test.");
 				return FWTS_SKIP;
 			}
-			if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_WAKEUP_TIME)
-				|| (var_runtimeservicessupported == 0)) {
+			if (var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_WAKEUP_TIME) {
 				fwts_passed(fw, "UEFI GetWakeupTime runtime service "
 					"supported status test passed.");
 			} else {
@@ -1346,8 +1335,7 @@ static int uefirttime_test38(fwts_framework *fw)
 			fwts_skipped(fw, "Unknow error occurred, skip test.");
 			return FWTS_SKIP;
 		}
-		if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_WAKEUP_TIME)
-			|| (var_runtimeservicessupported == 0)) {
+		if (var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_WAKEUP_TIME) {
 			fwts_passed(fw, "UEFI GetWakeupTime runtime service "
 				"supported status test passed.");
 		} else {

--- a/src/uefi/uefirttime/uefirttime.c
+++ b/src/uefi/uefirttime/uefirttime.c
@@ -1142,7 +1142,6 @@ static int uefirttime_test37(fwts_framework *fw)
 static int uefirttime_test38(fwts_framework *fw)
 {
 	long ioret;
-	bool getvar_supported;
 	uint32_t var_runtimeservicessupported;
 
 	struct efi_settime settime;
@@ -1155,17 +1154,7 @@ static int uefirttime_test38(fwts_framework *fw)
 	EFI_TIME efi_time;
 	EFI_TIME_CAPABILITIES efi_time_cap;
 
-	fwts_uefi_rt_support_status_get(fd, &getvar_supported,
-			&var_runtimeservicessupported);
-
-	if (!getvar_supported || (var_runtimeservicessupported == 0xFFFF)) {
-		fwts_skipped(fw, "Cannot get the RuntimeServicesSupported "
-				"variable, maybe the runtime service "
-				"GetVariable is not supported or "
-				"RuntimeServicesSupported not provided by "
-				"firmware.");
-		return FWTS_SKIP;
-	}
+	fwts_uefi_rt_support_status_get(fd, &var_runtimeservicessupported);
 
 	gettime.Capabilities = &efi_time_cap;
 	gettime.Time = &efi_time;

--- a/src/uefi/uefirtvariable/uefirtvariable.c
+++ b/src/uefi/uefirtvariable/uefirtvariable.c
@@ -2020,7 +2020,6 @@ static int uefirtvariable_test9(fwts_framework *fw)
 {
 	long ioret;
 
-	bool getvar_supported;
 	uint32_t var_runtimeservicessupported;
 
 	struct efi_getvariable getvariable;
@@ -2041,17 +2040,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
 	uint64_t getdatasize = sizeof(testdata);
 	uint32_t attr;
 
-	fwts_uefi_rt_support_status_get(fd, &getvar_supported,
-			&var_runtimeservicessupported);
-
-	if (!getvar_supported || (var_runtimeservicessupported == 0xFFFF)) {
-		fwts_skipped(fw, "Cannot get the RuntimeServicesSupported "
-				"variable, maybe the runtime service "
-				"GetVariable is not supported or "
-				"RuntimeServicesSupported not provided by "
-				"firmware.");
-		return FWTS_SKIP;
-	}
+	fwts_uefi_rt_support_status_get(fd, &var_runtimeservicessupported);
 
 	setvariable.VariableName = variablenametest;
 	setvariable.VendorGuid = &gtestguid1;

--- a/src/uefi/uefirtvariable/uefirtvariable.c
+++ b/src/uefi/uefirtvariable/uefirtvariable.c
@@ -2052,8 +2052,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
 	ioret = ioctl(fd, EFI_RUNTIME_SET_VARIABLE, &setvariable);
 	if (ioret == -1) {
 		if (status == EFI_UNSUPPORTED) {
-			if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_SET_VARIABLE)
-				|| (var_runtimeservicessupported == 0)) {
+			if (var_runtimeservicessupported & EFI_RT_SUPPORTED_SET_VARIABLE) {
 				fwts_failed(fw, LOG_LEVEL_HIGH, "UEFIRuntimeSetVariable",
 					"Get the Setvariable runtime service supported "
 					"via RuntimeServicesSupported variable. "
@@ -2067,8 +2066,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
 				fwts_skipped(fw, "Unknown error occurred, skip test.");
 				return FWTS_SKIP;
 			}
-			if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_SET_VARIABLE) ||
-				(var_runtimeservicessupported == 0)) {
+			if (var_runtimeservicessupported & EFI_RT_SUPPORTED_SET_VARIABLE) {
 				fwts_passed(fw, "UEFI SetVariable runtime service "
 					"supported status test passed.");
 			} else {
@@ -2083,8 +2081,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
 			fwts_skipped(fw, "Unknown error occurred, skip test.");
 			return FWTS_SKIP;
 		}
-		if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_SET_VARIABLE) ||
-			(var_runtimeservicessupported == 0)) {
+		if (var_runtimeservicessupported & EFI_RT_SUPPORTED_SET_VARIABLE) {
 			fwts_passed(fw, "UEFI SetVariable runtime service "
 				"supported status test passed.");
 		} else {
@@ -2105,8 +2102,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
 	ioret = ioctl(fd, EFI_RUNTIME_GET_VARIABLE, &getvariable);
 	if (ioret == -1) {
 		if (status == EFI_UNSUPPORTED) {
-			if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_VARIABLE)
-				|| (var_runtimeservicessupported == 0)) {
+			if (var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_VARIABLE) {
 				fwts_failed(fw, LOG_LEVEL_HIGH, "UEFIRuntimeGetVariable",
 					"Get the GetVariable runtime service supported "
 					"via RuntimeServicesSupported variable. "
@@ -2120,8 +2116,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
 				fwts_skipped(fw, "Unknown error occurred, skip test.");
 				return FWTS_SKIP;
 			}
-			if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_VARIABLE) ||
-				(var_runtimeservicessupported == 0)) {
+			if (var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_VARIABLE) {
 				fwts_passed(fw, "UEFI GetVariable runtime service "
 					"supported status test passed.");
 			} else {
@@ -2136,8 +2131,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
 			fwts_skipped(fw, "Unknown error occurred, skip test.");
 			return FWTS_SKIP;
 		}
-		if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_VARIABLE) ||
-			(var_runtimeservicessupported == 0)) {
+		if (var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_VARIABLE) {
 			fwts_passed(fw, "UEFI GetVariable runtime service "
 				"supported status test passed.");
 		} else {
@@ -2168,8 +2162,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
 	ioret = ioctl(fd, EFI_RUNTIME_GET_NEXTVARIABLENAME, &getnextvariablename);
 	if (ioret == -1) {
 		if (status == EFI_UNSUPPORTED) {
-			if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_NEXT_VARIABLE_NAME)
-				|| (var_runtimeservicessupported == 0)) {
+			if (var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_NEXT_VARIABLE_NAME) {
 				fwts_failed(fw, LOG_LEVEL_HIGH, "UEFIRuntimeGetNextVarName",
 					"Get the GetNextVarName runtime service supported "
 					"via RuntimeServicesSupported variable. "
@@ -2183,8 +2176,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
 				fwts_skipped(fw, "Unknown error occurred, skip test.");
 				return FWTS_SKIP;
 			}
-			if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_NEXT_VARIABLE_NAME)
-				|| (var_runtimeservicessupported == 0)) {
+			if (var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_NEXT_VARIABLE_NAME) {
 				fwts_passed(fw, "UEFI GetNextVarName runtime service "
 					"supported status test passed.");
 			} else {
@@ -2199,8 +2191,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
 			fwts_skipped(fw, "Unknown error occurred, skip test.");
 			return FWTS_SKIP;
 		}
-		if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_NEXT_VARIABLE_NAME)
-			|| (var_runtimeservicessupported == 0)) {
+		if (var_runtimeservicessupported & EFI_RT_SUPPORTED_GET_NEXT_VARIABLE_NAME) {
 			fwts_passed(fw, "UEFI GetNextVarName runtime service "
 				"supported status test passed.");
 		} else {
@@ -2221,8 +2212,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
 	ioret = ioctl(fd, EFI_RUNTIME_QUERY_VARIABLEINFO, &queryvariableinfo);
 	if (ioret == -1) {
 		if (status == EFI_UNSUPPORTED) {
-			if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_QUERY_VARIABLE_INFO)
-				|| (var_runtimeservicessupported == 0)) {
+			if (var_runtimeservicessupported & EFI_RT_SUPPORTED_QUERY_VARIABLE_INFO) {
 				fwts_failed(fw, LOG_LEVEL_HIGH, "UEFIRuntimeQueryVarInfo",
 					"Get the QueryVarInfo runtime service supported "
 					"via RuntimeServicesSupported variable. "
@@ -2236,8 +2226,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
 				fwts_skipped(fw, "Unknown error occurred, skip test.");
 				return FWTS_SKIP;
 			}
-			if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_QUERY_VARIABLE_INFO)
-				|| (var_runtimeservicessupported == 0)) {
+			if (var_runtimeservicessupported & EFI_RT_SUPPORTED_QUERY_VARIABLE_INFO) {
 				fwts_passed(fw, "UEFI QueryVarInfo runtime service "
 					"supported status test passed.");
 			} else {
@@ -2252,8 +2241,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
 			fwts_skipped(fw, "Unknown error occurred, skip test.");
 			return FWTS_SKIP;
 		}
-		if ((var_runtimeservicessupported & EFI_RT_SUPPORTED_QUERY_VARIABLE_INFO)
-			|| (var_runtimeservicessupported == 0)) {
+		if (var_runtimeservicessupported & EFI_RT_SUPPORTED_QUERY_VARIABLE_INFO) {
 			fwts_passed(fw, "UEFI QueryVarInfo runtime service "
 				"supported status test passed.");
 		} else {


### PR DESCRIPTION
The UEFI 2.8 Errata A specification has clarified that RuntimeServicesSupported is not a UEFI variable but a value in the 
EFI_RT_PROPERTIES_TABLE configuration table. Since Linux 5.11 the value can be retrieved via an IOCTL call.

Replace the code trying to read the non-existent RuntimeServicesSupported variable by the IOCTL call.

If RuntimeServicesSupported == 0, no runtime service is supported.